### PR TITLE
Add openshift mgr logic directly to pman as an option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ RUN apt-get update \
 COPY ./docker-entrypoint.py /dock/docker-entrypoint.py
 RUN chmod 777 /dock && chmod 777 /dock/docker-entrypoint.py
 ENTRYPOINT ["/dock/docker-entrypoint.py"]
+USER 1001
 EXPOSE 5010

--- a/pman/openshiftmgr.py
+++ b/pman/openshiftmgr.py
@@ -1,0 +1,156 @@
+"""
+OpenShift cluster manager module that provides functionality to schedule jobs as well as
+manage their state in the cluster.
+"""
+
+import yaml
+import json
+import os
+from kubernetes import client as k_client
+from openshift import client as o_client
+from openshift import config
+
+
+class OpenShiftManager(object):
+
+    def __init__(self, project=None):
+        self.openshift_client = None
+        self.kube_client = None
+        self.kube_v1_batch_client = None
+        self.project = project or os.environ.get('OPENSHIFTMGR_PROJECT') or 'myproject'
+
+        # init the openshift client
+        self.init_openshift_client()
+
+    def init_openshift_client(self):
+        """
+        Method to get a OpenShift client connected to remote or local OpenShift
+        """
+        kubecfg_path = os.environ.get('KUBECFG_PATH')
+        if kubecfg_path is None:
+            config.load_kube_config()
+        else:
+            config.load_kube_config(config_file=kubecfg_path)
+        self.openshift_client = o_client.OapiApi()
+        self.kube_client = k_client.CoreV1Api()
+        self.kube_v1_batch_client = k_client.BatchV1Api()
+
+    def schedule(self, image, command, name, mountdir=None):
+        """
+        Schedule a new job and returns the job object.
+        """
+        job_str = """
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: {name}
+spec:
+    parallelism: 1
+    completions: 1
+    activeDeadlineSeconds: 3600
+    template:
+        metadata:
+            name: {name}
+        spec:
+            restartPolicy: Never
+            containers:
+            - name: {name}
+              image: {image}
+              command: {command}
+""".format(name=name, command=str(command.split(" ")), image=image)
+
+        if mountdir is not None:
+            job_str = job_str + """
+              volumeMounts:
+              - mountPath: /share
+                name: openshiftmgr-storage
+            volumes: 
+            - name: openshiftmgr-storage
+              hostPath:
+                path: {mountdir}
+""".format(mountdir=mountdir)
+
+        job_yaml = yaml.load(job_str)
+        job = self.kube_v1_batch_client.create_namespaced_job(namespace=self.project, body=job_yaml)
+        return job
+
+    def create_pod(self, image, name):
+        """
+        Create a pod
+        """
+        pod_str = """
+apiVersion: v1
+kind: Pod
+metadata:
+    name: {name}
+spec:
+    restartPolicy: Never
+    containers:
+    - name: {name}
+      image: {image}
+""".format(name=name, image=image)
+
+        pod_yaml = yaml.load(pod_str)
+        pod = self.kube_client.create_namespaced_pod(namespace=self.project, body=pod_yaml)
+        return pod
+
+    def get_pod_status(self, name):
+        """
+        Get a pod's status
+        """
+        log = self.kube_client.read_namespaced_pod_status(namespace=self.project, name=name)
+        return log
+
+    def get_pod_log(self, name):
+        """
+        Get a pod log
+        """
+        log = self.kube_client.read_namespaced_pod_log(namespace=self.project, name=name)
+        return log
+
+    def get_job(self, name):
+        """
+        Get the previously scheduled job object
+        """
+        return self.kube_v1_batch_client.read_namespaced_job(name, self.project)
+
+    def remove(self, name):
+        """
+        Remove a previously scheduled job
+        """
+        self.kube_v1_batch_client.delete_namespaced_job(name, self.project, {})
+
+    def state(self, name):
+        """
+        Return the state of a previously scheduled job
+        """
+        job = self.get_job(name)
+        message = None
+        state = None
+        reason = None
+        if job.status.conditions:
+            for condition in job.status.conditions:
+                if condition.type == 'Failed' and condition.status == 'True':
+                    message = 'started'
+                    reason = condition.reason
+                    state = 'failed'
+                    break
+        if not state:
+            if job.status.completion_time and job.status.succeeded > 0:
+                message = 'finished'
+                state = 'complete'
+            elif job.status.active > 0:
+                message = 'started'
+                state = 'running'
+            else:
+                message = 'inactive'
+                state = 'inactive'
+
+        return {'Status': {'Message': message,
+                                'State': state,
+                                'Reason': reason,
+                                'Active': job.status.active,
+                                'Failed': job.status.failed,
+                                'Succeeded': job.status.succeeded,
+                                'StartTime': job.status.start_time,
+                                'CompletionTime': job.status.completion_time}}

--- a/pman/tests/test_openshiftmgr.py
+++ b/pman/tests/test_openshiftmgr.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import random
+import string
+import kubernetes
+from pman.openshiftmgr import OpenShiftManager
+
+class OpenShiftManagerTests(unittest.TestCase):
+    """
+    Test the OpenShiftManager's methods
+    """
+
+    @patch('pman.openshiftmgr.config.load_kube_config')
+    def setUp(self, mock_config):
+        self.project = 'myproject'
+        self.manager = OpenShiftManager(self.project)
+        self.manager.init_openshift_client()
+        self.job_name = 'job' + ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(10))
+        self.image = 'fedora'
+        self.command = 'echo test'
+
+    @patch('kubernetes.client.apis.batch_v1_api.BatchV1Api.create_namespaced_job')
+    def test_schedule(self, mock_create):
+        mock_create.return_value = kubernetes.client.models.v1_job.V1Job()
+        job = self.manager.schedule(self.image, self.command, self.job_name)
+        self.assertIsInstance(job, kubernetes.client.models.v1_job.V1Job)
+        #mock_create.assert_called_once() Available in 3.6
+
+    @patch('kubernetes.client.apis.batch_v1_api.BatchV1Api.read_namespaced_job')
+    def test_get_job(self, mock_get):
+        mock_get.return_value = kubernetes.client.models.v1_job.V1Job()
+        job = self.manager.get_job(self.job_name)
+        #mock_get.assert_called_once() Available in 3.6
+        mock_get.assert_any_call(self.job_name, self.project)
+        self.assertIsInstance(job, kubernetes.client.models.v1_job.V1Job)
+
+    @patch('kubernetes.client.apis.batch_v1_api.BatchV1Api.delete_namespaced_job')
+    def test_remove(self, mock_delete):
+        job = self.manager.remove(self.job_name)
+        #mock_delete.assert_called_once() Available in 3.6
+        mock_delete.assert_any_call(self.job_name, self.project, {})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
       author_email     =   'rudolph.pienaar@gmail.com',
       url              =   'https://github.com/FNNDSC/pman',
       packages         =   ['pman'],
-      install_requires =   ['pycurl', 'pyzmq', 'webob', 'pudb', 'psutil', 'docker'],
+      install_requires =   ['pycurl', 'pyzmq', 'webob', 'pudb', 'psutil', 'docker', 'openshift'],
       test_suite       =   'nose.collector',
       tests_require    =   ['nose'],
       scripts          =   ['bin/crunner', 'bin/pfioh', 'bin/pman', 'bin/purl', 'bin/snode'],


### PR DESCRIPTION
OpenShift is being added here as a sibling to "container".  I looked into adding the logic under the _container logic and it didn't go very smoothly.  In the end I came to the realization that "container" really means it's going to interact with the docker API and therefore a sibling element was the right level to abstract everything out into a different code path.