### PR TITLE
Docker pman repo re-naming

### DIFF
--- a/openshift/pman-openshift-template.json
+++ b/openshift/pman-openshift-template.json
@@ -70,7 +70,7 @@
                     "readOnly": true
                   }
                 ],
-                "image": "FNNDSC/pman",
+                "image": "fnndsc/pman",
                 "imagePullPolicy": "Always",
                 "name": "pman",
                 "ports": [


### PR DESCRIPTION
Was getting the following error, when I tried creating a pman pod.

`pman" with ErrImagePull: "Error response from daemon: {\"message\":\"invalid reference format: repository name must be lowercase\`

So changed the name of repo to lower-case.
cc @danmcp @awalkaradi95moc 