### PR TITLE
Fix case when trailing '/' messes up docker vol mounting in plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 #################
-pman - v1.6.12.2
+pman - v1.6.12.4
 #################
 
 .. image:: https://badge.fury.io/py/pman.svg

--- a/bin/pman
+++ b/bin/pman
@@ -34,7 +34,7 @@ except:
 
 str_defIP = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
 
-str_version = "1.6.12.2"
+str_version = "1.6.12.4"
 str_name    = 'pman'
 str_desc    = Colors.CYAN + """
 

--- a/pman/pman.py
+++ b/pman/pman.py
@@ -1655,6 +1655,8 @@ class Listener(threading.Thread):
                 # pudb.set_trace()
                 if 'shareDir' in d_env.keys():
                     str_shareDir            = d_env['shareDir']
+                    # Remove trailing '/' if it exists in shareDir
+                    str_shareDir    = str_shareDir.rstrip('/')
                 if 'STOREBASE' in os.environ:
                     str_storeBase           = os.environ['STOREBASE']
                     (str_origBase, str_key) = os.path.split(str_shareDir)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readme():
 
 setup(
       name             =   'pman',
-      version          =   '1.6.12.2',
+      version          =   '1.6.12.4',
       description      =   '(Python) Process Manager',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
Hi all --

For some reason sometimes in the integration testing, the directory ultimately passed to the plugin for input data has a trailing '/'. This breaks some processing on how to volume mount.

This code removes trailing '/' if they are there.

@danmcp 