### PR TITLE
Fix i/o dirs for swift to read from/write to

### DIFF
--- a/openshift/pman-swift-publisher/get_data.py
+++ b/openshift/pman-swift-publisher/get_data.py
@@ -60,7 +60,10 @@ class SwiftStore():
         fileBytes  = BytesIO(fileContent)
 
         zipfileObj = zipfile.ZipFile(fileBytes, 'r', compression = zipfile.ZIP_DEFLATED)
-        zipfileObj.extractall('/share')
+        # We are extracting to the file to /share/incoming in container as plugin container is hardcoded to read from
+        # /share/incoming.
+        # TODO: @ravig. Remove this hardcoding. Need to have named arguments in all plugins.
+        zipfileObj.extractall('/share/incoming')
         
 
 if __name__ == "__main__":

--- a/openshift/pman-swift-publisher/put_data.py
+++ b/openshift/pman-swift-publisher/put_data.py
@@ -62,16 +62,18 @@ class SwiftStore():
         key = 'someDefault'
         for k,v in kwargs.items():
             if k == 'path': 	      key         = v
-        fileName      = '/share/'
-        ziphandler    = zipfile.ZipFile('/share/ziparchive.zip', 'w', zipfile.ZIP_DEFLATED)
+        # The plugin container is hardcoded to output data to /share/outgoing after processing.
+        # TODO:@ravig. Remove this hardcoding.
+        fileName      = '/share/outgoing'
+        ziphandler    = zipfile.ZipFile('/share/outgoing/ziparchive.zip', 'w', zipfile.ZIP_DEFLATED)
     
         self.zipdir(fileName, ziphandler, arcroot = fileName)
 
         try:
-            with open('/share/ziparchive.zip','rb') as f:
+            with open('/share/outgoing/ziparchive.zip','rb') as f:
                 zippedFileContent = f.read()
         finally:
-            os.remove('/share/ziparchive.zip')
+            os.remove('/share/outgoing/ziparchive.zip')
 
         swiftHandler = SwiftHandler()
         self.swiftConnection = swiftHandler._initiateSwiftConnection()            


### PR DESCRIPTION
The swift backend for pfioh won't work for end-to-end. This is because the plugins are hardcoded to read from /share/incoming and write to /share/outgoing. As of now, I am adding those hardcodings to swift get data and put data files.

cc @danmcp @rudolphpienaar 