### PR TITLE
pman-swift-publisher Docker file fix to make it work

### DIFF
--- a/openshift/pman-swift-publisher/Dockerfile
+++ b/openshift/pman-swift-publisher/Dockerfile
@@ -13,8 +13,8 @@
 FROM fnndsc/ubuntu-python3:latest
 MAINTAINER fnndsc "dev@babymri.org"
 
-RUN apt-get install -y curl \
-    && apt-get update \
+RUN apt-get update \
+    && apt-get install -y curl \
     && pip3 install keystoneauth1 \ 
     && pip3 install python-swiftclient
 


### PR DESCRIPTION
Docker build as of now fails because of update not happening first. This should fix it.

cc @danmcp 