### PR TITLE
Better handling for cases when scheduler completely rejects job

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 #################
-pman - v1.6.16.4
+pman - v1.6.16.6
 #################
 
 .. image:: https://badge.fury.io/py/pman.svg

--- a/bin/pman
+++ b/bin/pman
@@ -34,7 +34,7 @@ except:
 
 str_defIP = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
 
-str_version = "1.6.16.4"
+str_version = "1.6.16.6"
 str_name    = 'pman'
 str_desc    = Colors.CYAN + """
 

--- a/pman/pman.py
+++ b/pman/pman.py
@@ -1422,6 +1422,8 @@ class Listener(threading.Thread):
         d_jobState          = {}
         hitIndex            = 0
         str_logs            = ""
+        b_status            = False
+        str_currentState    = "undefined"
 
         for k,v in kwargs.items():
             if k == 'jobState':         d_jobState          = v
@@ -1437,6 +1439,7 @@ class Listener(threading.Thread):
         if str_state == 'running' and str_message == 'started':
             str_currentState    = 'started'
             debug_print(str_jobRoot, d_serviceState, str_currentState, str_logs)
+            b_status    = True
         else:
             self.DB_store(d_serviceState,   '/%s/container' % (str_jobRoot), 'state')
             self.DB_store(str_logs,         '/%s/container' % (str_jobRoot), 'logs')
@@ -1447,11 +1450,16 @@ class Listener(threading.Thread):
             elif str_state == 'complete'    and str_message == 'finished':
                 str_currentState    = 'finishedSuccessfully'
                 debug_print(str_jobRoot, d_serviceState, str_currentState, str_logs)
+            b_status = True
         self.DB_store(str_currentState, '/%s/container' % (str_jobRoot), 'currentState')
+        if str_currentState == 'undefined':
+            self.dp.qprint('The state of the job is undefined!', comms = 'error')
+            self.dp.qprint('This typically means that the scheduler rejected the job.', comms = 'error')
+            self.dp.qprint('jobRoot = %s' % str_jobRoot, comms = 'error')
         return {
                     'currentState':     str_currentState,
                     'removeJob':        b_removeJob,
-                    'status':           True
+                    'status':           b_status
                 }
     
     def t_hello_process(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readme():
 
 setup(
       name             =   'pman',
-      version          =   '1.6.16.4',
+      version          =   '1.6.16.6',
       description      =   '(Python) Process Manager',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
``pman`` assumed implicitly that the scheduler would always accept a submitted job. This was shown to be false when external environmental conditions on file availability were not met. In such a case ``pman`` never handled this state and the processing thread would error out. 

This code should catch that condition and report an error to the ``pman`` console.
