### PR TITLE
Zipping fix for file reading

### DIFF
--- a/openshift/pman-swift-publisher/put_data.py
+++ b/openshift/pman-swift-publisher/put_data.py
@@ -4,7 +4,7 @@ SWIFT_KEY enviornment variable to be passed by the template
 """
 
 import os
-import zipfile
+import shutil
 from swift_handler import SwiftHandler
 
 
@@ -23,30 +23,6 @@ class SwiftStore():
         except Exception as exp:
             print('Exception = %s' %exp)
 
-    def zipdir(self, path, ziph, **kwargs):
-        """
-        Zip up a directory.
-
-        :param path:
-        :param ziph:
-        :param kwargs:
-        :return:
-        """
-        str_arcroot = ""
-        for k, v in kwargs.items():
-            if k == 'arcroot':  str_arcroot = v
-        for root, dirs, files in os.walk(path):
-            for file in files:
-                str_arcfile = os.path.join(root, file)
-                if len(str_arcroot):
-                    str_arcname = str_arcroot.split('/')[-1] + str_arcfile.split(str_arcroot)[1]
-                else:
-                    str_arcname = str_arcfile
-                try:
-                    ziph.write(str_arcfile, arcname=str_arcname)
-                except:
-                    print("Skipping %s" % str_arcfile)
-
     def storeData(self, **kwargs):
         """
         Creates an object of the file and stores it into the container as key-value object 
@@ -60,15 +36,12 @@ class SwiftStore():
         # TODO:@ravig. Remove this hardcoding.
         fileName = '/share/outgoing'
         # TODO: @ravig. The /tmp should be large enough to hold everything.
-        ziphandler = zipfile.ZipFile('/tmp/ziparchive.zip', 'w', zipfile.ZIP_DEFLATED)
-        self.zipdir(fileName, ziphandler, arcroot=fileName)
-
+        shutil.make_archive('/tmp/ziparchive', 'zip', fileName)
         try:
             with open('/tmp/ziparchive.zip','rb') as f:
                 #TODO: @ravig - Change this so that this is scalable.
                 zippedFileContent = f.read()
         finally:
-            ziphandler.close()
             os.remove('/tmp/ziparchive.zip')
 
         swiftHandler = SwiftHandler()


### PR DESCRIPTION
@danmcp The issue is with folder structure while zipping. We have additional outgoing folder(which should be basedir from which zipping should start) because of which f.read() after zipping is having additional content. This is being transferred to swift container.

It seems there is pythonic way of zipping content using shutil.make_archive which should make our life much more easier. I have tested this fix(https://kaizen.massopen.cloud/dashboard/project/containers/container/rg3001/output) but I didn't do a e2e using pfcon. 

EDIT: Tested with pfcon pointing to my pman in MOC's OpenShift deployment, it generated the correct zip file.