### PR TITLE
scale pman

### DIFF
--- a/pman/openshiftmgr.py
+++ b/pman/openshiftmgr.py
@@ -332,13 +332,14 @@ spec:
                 state = 'inactive'
 
         return {'Status': {'Message': message,
-                                'State': state,
-                                'Reason': reason,
-                                'Active': job.status.active,
-                                'Failed': job.status.failed,
-                                'Succeeded': job.status.succeeded,
-                                'StartTime': str(job.status.start_time),
-                                'CompletionTime': str(job.status.completion_time)}}
+                                    'State': state,
+                                    'Reason': reason,
+                                    'Active': job.status.active,
+                                    'Failed': job.status.failed,
+                                    'Succeeded': job.status.succeeded,
+                                    'StartTime': str(job.status.start_time),
+                                    'CompletionTime': str(job.status.completion_time)}}
+   
 
     def get_job_pod_logs(self, pod_name):
         """


### PR DESCRIPTION
@danmcp @ravisantoshgudimetla 
Scaling pman by removing pman intrenal ptree. The command to check status for a job doesn't not uses p-tree, instead queries OpenShift API.

These are commands that do not use ptree any more:
`run`
`status`

Additional changes to do:
- modify pman to execute other commands like `get`, `info`, `quit`,`search` that w/o ptree
- cleaning job pods after job is done