### PR TITLE
Remove spurious 'import pman' and bump to 2.0.0.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 #################
-pman - v2.0.0.4
+pman - v2.0.0.6
 #################
 
 .. image:: https://badge.fury.io/py/pman.svg

--- a/bin/pman
+++ b/bin/pman
@@ -15,7 +15,6 @@ from    distutils.sysconfig import get_python_lib
 from    argparse            import RawTextHelpFormatter
 from    argparse            import ArgumentParser
 import  socket
-import  pman
 import  threading
 
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), '../pman'))
@@ -30,7 +29,7 @@ from pfmisc._colors         import Colors
 
 str_defIP = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
 
-str_version = "2.0.0.4"
+str_version = "2.0.0.6"
 str_name    = 'pman'
 str_desc    = Colors.CYAN + """
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readme():
 
 setup(
       name             =   'pman',
-      version          =   '2.0.0.4',
+      version          =   '2.0.0.6',
       description      =   '(Python) Process Manager',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
A lingering "import pman" was contextually out of place and caused failure when run on de novo installations. Bug was masked if a previous "pip install pman" had been called.