### PR TITLE
Fix verbosity level in pman template

### DIFF
--- a/openshift/pman-openshift-template-without-swift.json
+++ b/openshift/pman-openshift-template-without-swift.json
@@ -51,6 +51,7 @@
                 "--http",
                 "--port=5010",
                 "--listeners=12",
+		  "--verbosity=1",
                 "--container-env=openshift",
                 "--enableTokenAuth",
                 "--tokenPath=/etc/pman/auth/pman_config.cfg"

--- a/openshift/pman-openshift-template.json
+++ b/openshift/pman-openshift-template.json
@@ -51,6 +51,7 @@
                 "--http",
                 "--port=5010",
                 "--listeners=12",
+		  "--verbosity=1",
                 "--container-env=openshift",
                 "--enableTokenAuth",
                 "--tokenPath=/etc/pman/auth/pman_config.cfg"


### PR DESCRIPTION
cc @danmcp 

This fixes pman and pfioh not logging in openshift case.

BTW, had some alignment issues while pushing code to github. Look at the alignment of verbosity line below, you could see some 2 spaces extra.

```
"spec": {
            "containers": [{
              "command": [
                "/usr/local/bin/pman",
                "--rawmode=1",
                "--http",
                "--port=5010",
                "--listeners=12",
                  "--verbosity=1",
                "--container-env=openshift",
                "--enableTokenAuth",
                "--tokenPath=/etc/pman/auth/pman_config.cfg"
              ],

```