### PR TITLE
Set --verbosity to 1 by default

### DIFF
--- a/bin/pman
+++ b/bin/pman
@@ -271,7 +271,7 @@ parser.add_argument(
     "-v", "--verbosity",
     help    = "verbosity level for app",
     dest    = 'verbosity',
-    default = "0")
+    default = "1")
 parser.add_argument(
     "-x", "--desc",
     help    = "long synopsis",

--- a/pman/crunner.py
+++ b/pman/crunner.py
@@ -169,7 +169,7 @@ class crunner(object):
         self.b_echoCmd          = False
 
         # Debugging
-        self.verbosity          = 0
+        self.verbosity          = 1
 
         # Toggle special handling of "compound" jobs
         self.l_cmd              = []

--- a/pman/pman.py
+++ b/pman/pman.py
@@ -154,7 +154,7 @@ class pman(object):
         self.str_debugFile      = '/dev/null'
         self.b_debugToFile      = True
         self.pp                 = pprint.PrettyPrinter(indent=4)
-        self.verbosity          = 0
+        self.verbosity          = 1
 
         # Authentication parameters
         self.b_tokenAuth        = False
@@ -481,7 +481,7 @@ class FileIO(threading.Thread):
         self.within             = None
 
         self.b_stopThread       = False
-        self.verbosity          = 0
+        self.verbosity          = 1
 
         # Debug parameters
         self.str_debugFile      = '/dev/null'
@@ -537,7 +537,7 @@ class Listener(threading.Thread):
         self.str_jobRootDir     = ''
 
         self.listenerSleep      = 0.1
-        self.verbosity          = 0
+        self.verbosity          = 1
 
         self.jid                = ''
         self.auid               = ''
@@ -2223,7 +2223,7 @@ class Poller(threading.Thread):
         # Debug parameters
         self.str_debugFile      = '/dev/null'
         self.b_debugToFile      = True
-        self.verbosity          = 0
+        self.verbosity          = 1
 
         for key,val in kwargs.items():
             if key == 'pollTime':       self.pollTime       = val
@@ -2288,7 +2288,7 @@ class Crunner(threading.Thread):
         # Debug parameters
         self.str_debugFile      = '/dev/null'
         self.b_debugToFile      = True
-        self.verbosity          = 0
+        self.verbosity          = 1
 
         for k,v in kwargs.items():
             if k == 'cmd':          self.str_cmd        = v


### PR DESCRIPTION
This ensures that logs are always printed whenever we
start pman.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>