### PR TITLE
Fix get pod logs with job id having - and update delete pvc api

### DIFF
--- a/pman/openshiftmgr.py
+++ b/pman/openshiftmgr.py
@@ -346,7 +346,7 @@ spec:
                                     'CompletionTime': job.status.completion_time}}
    
 
-    def get_job_pod_logs(self, pod_name):
+    def get_job_pod_logs(self, pod_name, jid):
         """
         Returns the concatenated log of all 3 containers part of job template.
         :param str pod_name: job-id of OpenShift job.  
@@ -354,10 +354,8 @@ spec:
         """
         # Assumption is pod is always going to have a init-storage, container with job-id, publish container, if not we just return log for job container.
         # TODO: @ravig: Think of a better way to abstract out logs in case of multiple pods running parallelly.
-        
-        # job-id is pod_name.split('-')[0]
-        plugin_container = pod_name.split('-')[0]
-        job_container_log = self.get_pod_log(pod_name, plugin_container)
+
+        job_container_log = self.get_pod_log(pod_name, jid)
         try: 
             init_container_log = self.get_pod_log(pod_name, 'init-storage')
         except ApiException:
@@ -409,4 +407,6 @@ spec:
         """
         Remove pvc created
         """
-        self.kube_client.delete_namespaced_persistent_volume_claim(job_id+"-storage-claim", self.project, {})
+        pvc_name = job_id+"-storage-claim"
+        body = k_client.V1DeleteOptions()
+        self.kube_client.delete_namespaced_persistent_volume_claim(pvc_name, self.project, body=body)

--- a/pman/pman.py
+++ b/pman/pman.py
@@ -1423,7 +1423,7 @@ class Listener(threading.Thread):
         if d_json['Status']['Message'] == 'finished':
             pod_names = self.get_openshift_manager().get_pod_names_in_job(jid)
             for _, pod_name in enumerate(pod_names):
-                str_logs += self.get_openshift_manager().get_job_pod_logs(pod_name)
+                str_logs += self.get_openshift_manager().get_job_pod_logs(pod_name, jid)
         else:
             str_logs = d_json['Status']['Message']
 
@@ -1806,7 +1806,6 @@ class Listener(threading.Thread):
         d_env               = {}
 
         self.dp.qprint('Processing swarm-type job...')
-
         for k,v in kwargs.items():
             if k == 'request': d_request    = v
 


### PR DESCRIPTION
- Updated `delete` command to use updated `delete_namespaced_persistent_volume_claim` API

- Get `status` command was breaking for jobs with `-` in job-id, 
e.g for below job, pman would give Time Out Error. 
``` \
'{  "action": "status",
        "meta": {
                "key":          "jid",
                "value":        "1fa2d866-59b1-4f59-b0b2-aa753a7695f8"
        }
}' --quiet --jsonpprintindent 4 




