### PR TITLE
Persistent Volume claim adjusted to MOC cluster

### DIFF
--- a/pman/openshiftmgr.py
+++ b/pman/openshiftmgr.py
@@ -418,7 +418,7 @@ spec:
                 ],
                 "resources": {
                     "requests": {
-                        "storage": "5Gi"
+                        "storage": "2Gi"
                     }
                 }
             }


### PR DESCRIPTION
The persistent volume claim storage is adjusted according to the MOC cluster. 

![Screenshot from 2021-02-11 16-34-35](https://user-images.githubusercontent.com/55101879/107701732-4fcaaf00-6c87-11eb-8e20-896ebb8f618c.png)


