### PR TITLE
Make pman dev environment be based on a docker swarm stack

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-# Variables declared here are available to
-# docker-compose -f docker-compose_dev.yml on execution
-PMANREPO=fnndsc
-host=fnndsc
-TAG=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,8 @@ jobs:
           docker swarm init --advertise-addr 127.0.0.1
           docker build --build-arg ENVIRONMENT=local -t fnndsc/pman:dev .
           ./make.sh -s -U -i
-          export pman_dev=$(docker ps -f name=pman_dev_stack_pman_service.1 -q)
       - name: nosetests
-        run: docker exec $pman_dev nosetests --exe tests
+        run: docker exec $(docker ps -f name=pman_dev_stack_pman_service.1 -q) nosetests --exe tests
       - name: teardown
         run: |
           ./unmake.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,14 @@ jobs:
       - name: provision local services
         run: |
           docker swarm init --advertise-addr 127.0.0.1
-          chmod -R 755 $PWD
-          mkdir -p FS/remote
-          chmod -R 777 FS
-          export STOREBASE=$PWD/FS/remote
-          docker-compose -f docker-compose_dev.yml up -d
+          docker build --build-arg ENVIRONMENT=local -t fnndsc/pman:dev .
+          ./make.sh -s -U -i
+          export pman_dev=$(docker ps -f name=pman_dev_stack_pman_service.1 -q)
       - name: nosetests
-        run: docker-compose -f docker-compose_dev.yml exec -T pman_service nosetests --exe tests
+        run: docker exec $pman_dev nosetests --exe tests
       - name: teardown
         run: |
-          docker-compose -f docker-compose_dev.yml down -v
+          ./unmake.sh
           sudo rm -fr ./FS
           docker swarm leave --force
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Overview
 
 This repository implements ``pman`` -- a process manager that provides a unified API over HTTP for running jobs on
 
-* docker swarm
+* Docker Swarm
 * Openshift
 
 ***********************
@@ -30,17 +30,25 @@ Development and testing
 Preconditions
 =============
 
-Install latest Docker and Docker Compose
-----------------------------------------
+Install latest docker
+---------------------
 
 Currently tested platforms:
 
 * ``Ubuntu 18.04+ and MAC OS X 10.14+ and Fedora 31+`` ([Additional instructions for Fedora](https://github.com/mairin/ChRIS_store/wiki/Getting-the-ChRIS-Store-to-work-on-Fedora))
 * ``Docker 18.06.0+``
-* ``Docker Compose 1.27.0+``
 
 Note: On a Linux machine make sure to add your computer user to the ``docker`` group.
 Consult this page https://docs.docker.com/engine/install/linux-postinstall/
+
+
+Start a local Docker Swarm cluster if not already started
+=========================================================
+
+.. code-block:: bash
+
+    docker swarm init --advertise-addr 127.0.0.1
+
 
 Start pman's Flask development server
 =====================================
@@ -59,6 +67,14 @@ You can later remove all the backend containers with:
     $> ./unmake.sh
 
 
+Remove the local Docker Swarm cluster if desired
+================================================
+
+.. code-block:: bash
+
+    docker swarm leave --force
+
+
 Example Job
 ===========
 
@@ -66,7 +82,7 @@ Simulate incoming data
 
 .. code-block:: bash
 
-    pman_dev=$(docker ps -f ancestor=fnndsc/pman:dev -f name=pman_service -q)  
+    pman_dev=$(docker ps -f name=pman_dev_stack_pman_service.1 -q)
     docker exec -it $pman_dev mkdir -p /home/localuser/storeBase/key-chris-jid-1/incoming
     docker exec -it $pman_dev mkdir -p /home/localuser/storeBase/key-chris-jid-1/outgoing
     docker exec -it $pman_dev touch /home/localuser/storeBase/key-chris-jid-1/incoming/test.txt

--- a/docker-compose_dev.yml
+++ b/docker-compose_dev.yml
@@ -12,11 +12,9 @@ version: '3.7'
 
 services:
   pman_service:
-    image: ${PMANREPO}/pman:dev
-    build:
-      context: .
-      args:
-        ENVIRONMENT: local
+    image: ${PMANREPO:?}/pman:dev
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
     command: ["pman", "--ip", "0.0.0.0", "--verbosity", "1"]
     # During dev pman needs access to the pfcon storeBase folder (and hence the volume)
     # mapping from the HOST file system space to be able to run the tests. This is not
@@ -30,7 +28,7 @@ services:
       - APPLICATION_MODE=development
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
-      - ${STOREBASE}:/home/localuser/storeBase:z
+      - ${STOREBASE:?}:/home/localuser/storeBase:z
       - ./pman:/home/localuser/pman/pman:z
       - ./bin:/home/localuser/pman/bin:z
       - ./tests:/home/localuser/pman/tests:z

--- a/make.sh
+++ b/make.sh
@@ -6,21 +6,19 @@
 #
 # SYNPOSIS
 #
-#   make.sh                     [-r <service>]                  \
-#                               [-a <swarm-advertise-adr>]      \
-#                               [-p] [-i] [-s]                  \
+#   make.sh                     [-i] [-s] [-U]                 \
 #                               [-S <storeBaseOverride>]        \
 #                               [local|fnndsc[:dev]]
 #
 # DESC
 #
-#   'make.sh' sets up a pman development instance using docker-compose.
+#   'make.sh' sets up a pman development instance using docker stack deploy.
 #   It can also optionally create a pattern of directories and symbolic links
-#   that reflect the declarative environment of the docker-compose contents.
+#   that reflect the declarative environment of the docker-compose_dev.yml contents.
 #
 # TYPICAL CASES:
 #
-#   Run full pfcom instantiation:
+#   Run full pman instantiation:
 #
 #       unmake.sh ; sudo rm -fr FS; rm -fr FS; make.sh
 #
@@ -31,11 +29,6 @@
 # ARGS
 #
 #
-#   -r <service>
-#
-#       Restart <service> in interactive mode. This is mainly for debugging
-#       and is typically used to restart the 'pman' service.
-#
 #   -S <storeBaseOverride>
 #
 #       Explicitly set the STOREBASE dir to <storeBaseOverride>. This is useful
@@ -43,27 +36,19 @@
 #       between the actual STOREBASE path and the text of the path shared between
 #       the macOS host and the docker VM.
 #
-#   -a <swarm-advertise-adr>
-#
-#       If specified, pass <swarm-advertise-adr> to swarm init.
-#
 #   -i
 #
-#       Optional do not restart final pman in interactive mode.
+#       Optional do not automatically attach interactive terminal to pman container.
+#
+#   -U
+#
+#       Optional skip the UNIT tests.
 #
 #   -s
 #
 #       Optional skip intro steps. This skips the check on latest versions
 #       of containers and the interval version number printing. Makes for
 #       slightly faster startup.
-#
-#   -p
-#
-#       Optional pause after instantiating system to allow user to stop
-#       and restart services in interactive mode. User stops and restarts
-#       services explicitly with
-#
-#               docker stop <ID> && docker rm -vf <ID> && *make* -r <service>
 #
 #   [local|fnndsc[:dev]] (optional, default = 'fnndsc')
 #
@@ -85,27 +70,16 @@ source ./decorate.sh
 source ./cparse.sh
 
 declare -i STEP=0
-declare -i b_restart=0
-JOB=""
 HERE=$(pwd)
 echo "Starting script in dir $HERE"
 
-CREPO=fnndsc
-TAG=
+export PMANREPO=fnndsc
+export TAG=
 
-if [[ -f .env ]] ; then
-    source .env
-fi
-
-while getopts "r:psiUa:S:" opt; do
+while getopts "siUa:S:" opt; do
     case $opt in
-        r) b_restart=1
-           JOB=$OPTARG                          ;;
-        p) b_pause=1                            ;;
         s) b_skipIntro=1                        ;;
-        i) b_norestartinteractive_chris_dev=1   ;;
-        a) b_swarmAdvertiseAdr=1
-            SWARMADVERTISEADDR=$OPTARG          ;;
+        i) b_norestartinteractive_pman_dev=1   ;;
         U) b_skipUnitTests=1                    ;;
         S) b_storeBaseOverride=1
            STOREBASE=$OPTARG                    ;;
@@ -115,7 +89,7 @@ done
 shift $(($OPTIND - 1))
 if (( $# == 1 )) ; then
     REPO=$1
-    export CREPO=$(echo $REPO | awk -F \: '{print $1}')
+    export PMANREPO=$(echo $REPO | awk -F \: '{print $1}')
     export TAG=$(echo $REPO | awk -F \: '{print $2}')
     if (( ${#TAG} )) ; then
         TAG=":$TAG"
@@ -141,196 +115,125 @@ title -d 1 "Setting global exports..."
     export STOREBASE=$STOREBASE
 windowBottom
 
-if (( b_restart )) ; then
-    title -d 1 "Restarting ${JOB} service"                              \
-                    "in interactive mode..."
-    printf "${LightCyan}%40s${LightGreen}%40s\n"                        \
-                "Stopping" "${JOB}_service"                             | ./boxes.sh
-    windowBottom
 
-    docker-compose -f docker-compose_dev.yml stop ${JOB}_service >& dc.out > /dev/null
-    echo -en "\033[2A\033[2K"
-    cat dc.out | ./boxes.sh
-
-    printf "${LightCyan}%40s${LightGreen}%40s\n"                        \
-                "rm -f" "${JOB}_service"                                | ./boxes.sh
-    windowBottom
-
-    docker-compose -f docker-compose_dev.yml rm -f ${JOB}_service >& dc.out > /dev/null
-    echo -en "\033[2A\033[2K"
-    cat dc.out | ./boxes.sh
-    windowBottom
-
-    docker-compose -f docker-compose_dev.yml run --service-ports ${JOB}_service
-else
+if (( ! b_skipIntro )) ; then
     title -d 1 "Pulling non-'local/' core containers where needed..."   \
-                "and creating appropriate .env for docker-compose_dev.yml"
-    if (( ! b_skipIntro )) ; then
-        echo "# Variables declared here are available to"               > .env
-        echo "# docker-compose -f docker-compose_dev.yml on execution"                            >>.env
-        for CORE in ${A_CONTAINER[@]} ; do
-            cparse $CORE " " "REPO" "CONTAINER" "MMN" "ENV"
-            echo "${ENV}=${REPO}"                                       >>.env
-            if [[ $REPO != "local" ]] ; then
-                echo ""                                                 | ./boxes.sh
-                CMD="docker pull ${REPO}/$CONTAINER"
-                printf "${LightCyan}%-40s${Green}%40s${Yellow}\n"       \
-                            "docker pull" "${REPO}/$CONTAINER"          | ./boxes.sh
-                windowBottom
-                sleep 1
-                echo $CMD | sh                                          | ./boxes.sh -c
-            fi
-        done
-        echo "TAG="                                                     >>.env
-    fi
-    windowBottom
-
-    if (( ! b_skipIntro )) ; then
-        title -d 1 "Will use containers with following version info:"
-        for CORE in ${A_CONTAINER[@]} ; do
-            cparse $CORE " " "REPO" "CONTAINER" "MMN" "ENV"
-            if [[   $CONTAINER != "pl-simplefsapp"  ]] ; then
-                windowBottom
-                CMD="docker run --entrypoint $CONTAINER ${REPO}/$CONTAINER --version"
-                if [[   $CONTAINER == "pman:dev"  ]] ; then
-                  CMD="docker run --entrypoint pman ${REPO}/$CONTAINER --version"
-                fi
-                Ver=$(echo $CMD | sh | grep Version)
-                echo -en "\033[2A\033[2K"
-                printf "${White}%40s${Green}%40s${Yellow}\n"            \
-                        "${REPO}/$CONTAINER" "$Ver"                     | ./boxes.sh
-            fi
-        done
-    fi
-
-    title -d 1 "Stopping and restarting the docker swarm... "
-        docker swarm leave --force >dc.out 2>dc.out
-        cat dc.out | ./boxes.sh
-        if (( b_swarmAdvertiseAdr )) ; then
-            docker swarm init --advertise-addr=$SWARMADVERTISEADDR      |\
-                sed 's/[[:alnum:]]+:/\n&/g' | sed -E 's/(.{80})/\1\n/g' | ./boxes.sh
-        else
-            docker swarm init --advertise-addr 127.0.0.1                |\
-                sed 's/[[:alnum:]]+:/\n&/g' | sed -E 's/(.{80})/\1\n/g' | ./boxes.sh
-        fi
-        echo "Swarm started"                                            | ./boxes.sh
-    windowBottom
-
-    title -d 1 "Shutting down any running pman and related containers... "
-        echo "This might take a few minutes... please be patient."              | ./boxes.sh ${Yellow}
-        windowBottom
-        docker-compose -f docker-compose_dev.yml stop >& dc.out > /dev/null
-        echo -en "\033[2A\033[2K"
-        cat dc.out | sed -E 's/(.{80})/\1\n/g'                                  | ./boxes.sh ${LightBlue}
-        docker-compose -f docker-compose_dev.yml rm -vf >& dc.out > /dev/null
-        cat dc.out | sed -E 's/(.{80})/\1\n/g'                                  | ./boxes.sh ${LightCyan}
-        for CORE in ${A_CONTAINER[@]} ; do
-            cparse $CORE " " "REPO" "CONTAINER" "MMN" "ENV"
-            docker ps -a                                                        |\
-                grep $CONTAINER                                                 |\
-                awk '{printf("docker stop %s && docker rm -vf %s\n", $1, $1);}' |\
-                sh >/dev/null                                                   | ./boxes.sh
-            printf "${White}%40s${Green}%40s${NC}\n"                            \
-                        "$CONTAINER" "stopped"                                  | ./boxes.sh
-        done
-    windowBottom
-
-    title -d 1 "Changing permissions to 755 on" "$(pwd)"
-        cd $HERE
-        echo "chmod -R 755 $(pwd)"                                      | ./boxes.sh
-        chmod -R 755 $(pwd)
-    windowBottom
-
-    title -d 1 "Checking that FS directory tree is empty..."
-        mkdir -p FS/remote
-        chmod -R 777 FS
-        b_FSOK=1
-        type -all tree >/dev/null 2>/dev/null
-        if (( ! $? )) ; then
-            tree FS                                                     | ./boxes.sh
-            report=$(tree FS | tail -n 1)
-            if [[ "$report" != "1 directory, 0 files" ]] ; then
-                b_FSOK=0
-            fi
-        else
-            report=$(find FS 2>/dev/null)
-            lines=$(echo "$report" | wc -l)
-            if (( lines != 2 )) ; then
-                b_FSOK=0
-            fi
-            echo "lines is $lines"
-        fi
-        if (( ! b_FSOK )) ; then
-            printf "There should only be 1 directory and no files in the FS tree!\n"    | ./boxes.sh ${Red}
-            printf "Please manually clean/delete the entire FS tree and re-run.\n"      | ./boxes.sh ${Yellow}
-            printf "\nThis script will now exit with code '1'.\n\n"                     | ./boxes.sh ${Yellow}
-            exit 1
-        fi
-        printf "${LightCyan}%40s${LightGreen}%40s\n"                    \
-                    "Tree state" "[ OK ]"                               | ./boxes.sh
-    windowBottom
-
-    title -d 1 "Starting pman containerized development environment "
-        echo "This might take a few minutes... please be patient."      | ./boxes.sh ${Yellow}
-        echo "docker-compose -f docker-compose_dev.yml  up -d"          | ./boxes.sh ${LightCyan}
-        windowBottom
-        docker-compose -f docker-compose_dev.yml up -d >& dc.out > /dev/null
-        echo -en "\033[2A\033[2K"
-        cat dc.out | sed -E 's/(.{80})/\1\n/g'                          | ./boxes.sh ${LightGreen}
-    windowBottom
-
-    if (( ! b_skipUnitTests )) ; then
-        title -d 1 "Running pman tests..."
-        echo "This might take a few minutes... please be patient."      | ./boxes.sh ${Yellow}
-        windowBottom
-        docker-compose -f docker-compose_dev.yml exec pman_service nosetests --exe tests
-        status=$?
-        title -d 1 "pman test results"
-        if (( $status == 0 )) ; then
-            printf "%40s${LightGreen}%40s${NC}\n"                       \
-                "pman tests" "[ success ]"                         | ./boxes.sh
-        else
-            printf "%40s${Red}%40s${NC}\n"                              \
-                "pman tests" "[ failure ]"                         | ./boxes.sh
-        fi
-        windowBottom
-    fi
-
-    title -d 1 "Pause for manual restart of services?"
-    if (( b_pause )) ; then
-        echo "Pausing... hit *ANY* key to continue"                     | ./boxes.sh
-        windowBottom
-        old_stty_cfg=$(stty -g)
-        stty raw -echo ; REPLY=$(head -c 1) ; stty $old_stty_cfg
-        echo -en "\033[2A\033[2K"
-        echo "Resuming..."                                              | ./boxes.sh
-    fi
-    windowBottom
-
-
-    if (( !  b_norestartinteractive_chris_dev )) ; then
-        title -d 1 "Restarting pman development server"                \
-                            "in interactive mode..."
-            printf "${LightCyan}%40s${LightGreen}%40s\n"                \
-                        "Stopping" "pman_service"                      | ./boxes.sh
+            "and creating appropriate .env for docker-compose_dev.yml"
+    echo "# Variables declared here are available to"               > .env
+    echo "# docker stack deploy -c docker-compose_dev.yml on execution"                            >>.env
+    for CORE in ${A_CONTAINER[@]} ; do
+        cparse $CORE " " "REPO" "CONTAINER" "MMN" "ENV"
+        echo "${ENV}=${REPO}"                                       >>.env
+        if [[ $REPO != "local" ]] ; then
+            echo ""                                                 | ./boxes.sh
+            CMD="docker pull ${REPO}/$CONTAINER"
+            printf "${LightCyan}%-40s${Green}%40s${Yellow}\n"       \
+                        "docker pull" "${REPO}/$CONTAINER"          | ./boxes.sh
             windowBottom
-            docker-compose -f docker-compose_dev.yml stop pman_service >& dc.out > /dev/null
-            echo -en "\033[2A\033[2K"
-            cat dc.out | ./boxes.sh
+            sleep 1
+            echo $CMD | sh                                          | ./boxes.sh -c
+        fi
+    done
+    echo "TAG="                                                     >>.env
+    windowBottom
+fi
 
-            printf "${LightCyan}%40s${LightGreen}%40s\n"                \
-                        "rm -f" "pman_service"                         | ./boxes.sh
-            windowBottom
-            docker-compose -f docker-compose_dev.yml rm -f pman_service >& dc.out > /dev/null
-            echo -en "\033[2A\033[2K"
-            cat dc.out | ./boxes.sh
+title -d 1 "Shutting down any running pman and related containers... "
+    echo "This might take a few minutes... please be patient."              | ./boxes.sh ${Yellow}
+    windowBottom
+    docker stack rm pman_dev_stack >& dc.out > /dev/null
+    echo -en "\033[2A\033[2K"
+    cat dc.out | sed -E 's/(.{80})/\1\n/g'                                  | ./boxes.sh ${LightBlue}
+    for CORE in ${A_CONTAINER[@]} ; do
+        cparse $CORE " " "REPO" "CONTAINER" "MMN" "ENV"
+        docker ps -a                                                        |\
+            grep $CONTAINER                                                 |\
+            awk '{printf("docker stop %s && docker rm -vf %s\n", $1, $1);}' |\
+            sh >/dev/null                                                   | ./boxes.sh
+        printf "${White}%40s${Green}%40s${NC}\n"                            \
+                    "$CONTAINER" "stopped"                                  | ./boxes.sh
+    done
+windowBottom
 
+title -d 1 "Changing permissions to 755 on" "$(pwd)"
+    cd $HERE
+    echo "chmod -R 755 $(pwd)"                                      | ./boxes.sh
+    chmod -R 755 $(pwd)
+windowBottom
 
-            printf "${LightCyan}%40s${LightGreen}%40s\n"                \
-                        "Starting in interactive mode" "pman"          |./boxes.sh
-            windowBottom
-            docker-compose -f docker-compose_dev.yml                    \
-                run --service-ports pman_service
+title -d 1 "Checking that FS directory tree is empty..."
+    mkdir -p FS/remote
+    chmod -R 777 FS
+    b_FSOK=1
+    type -all tree >/dev/null 2>/dev/null
+    if (( ! $? )) ; then
+        tree FS                                                     | ./boxes.sh
+        report=$(tree FS | tail -n 1)
+        if [[ "$report" != "1 directory, 0 files" ]] ; then
+            b_FSOK=0
+        fi
+    else
+        report=$(find FS 2>/dev/null)
+        lines=$(echo "$report" | wc -l)
+        if (( lines != 2 )) ; then
+            b_FSOK=0
+        fi
+        echo "lines is $lines"
     fi
+    if (( ! b_FSOK )) ; then
+        printf "There should only be 1 directory and no files in the FS tree!\n"    | ./boxes.sh ${Red}
+        printf "Please manually clean/delete the entire FS tree and re-run.\n"      | ./boxes.sh ${Yellow}
+        printf "\nThis script will now exit with code '1'.\n\n"                     | ./boxes.sh ${Yellow}
+        exit 1
+    fi
+    printf "${LightCyan}%40s${LightGreen}%40s\n"                    \
+                "Tree state" "[ OK ]"                               | ./boxes.sh
+windowBottom
 
+title -d 1 "Starting pman_dev_stack containerized dev environment on Swarm"
+    echo "docker stack deploy -c docker-compose_dev.yml pman_dev_stack" | ./boxes.sh ${LightCyan}
+    windowBottom
+    docker stack deploy -c docker-compose_dev.yml pman_dev_stack >& dc.out > /dev/null
+    echo -en "\033[2A\033[2K"
+    cat dc.out | sed -E 's/(.{80})/\1\n/g'                          | ./boxes.sh ${LightGreen}
+windowBottom
+
+title -d 1 "Waiting until containers for pman_dev_stack are running on Swarm"
+    echo "This might take a few minutes... please be patient."      | ./boxes.sh ${Yellow}
+    windowBottom
+    for i in {1..20}; do
+      sleep 5
+      pman_dev=$(docker ps -f name=pman_dev_stack_pman_service.1 -q)
+      if [ -n "$pman_dev" ]; then
+        echo "Success: pman_dev_stack's containers are up"      | ./boxes.sh ${Green}
+        break
+      fi
+    done
+    if [ -z "$pman_dev" ]; then
+        echo "Error: couldn't start pman_dev_stack's containers"      | ./boxes.sh ${Red}
+    fi
+windowBottom
+
+if (( ! b_skipUnitTests )) ; then
+    title -d 1 "Running pman tests..."
+    echo "This might take a few minutes... please be patient."      | ./boxes.sh ${Yellow}
+    windowBottom
+    docker exec $pman_dev nosetests --exe tests
+    status=$?
+    title -d 1 "pman test results"
+    if (( $status == 0 )) ; then
+        printf "%40s${LightGreen}%40s${NC}\n"                       \
+            "pman tests" "[ success ]"                         | ./boxes.sh
+    else
+        printf "%40s${Red}%40s${NC}\n"                              \
+            "pman tests" "[ failure ]"                         | ./boxes.sh
+    fi
+    windowBottom
+fi
+
+if (( !  b_norestartinteractive_pman_dev )) ; then
+    title -d 1 "Attaching interactive terminal"                \
+                        "(ctrl-a to detach)"
+    docker logs $pman_dev
+    docker attach --detach-keys ctrl-a $pman_dev
 fi

--- a/unmake.sh
+++ b/unmake.sh
@@ -6,15 +6,13 @@ declare -i STEP=0
 
 export STOREBASE=${STOREBASE}
 
-title -d 1 "Destroying pman containerized development environment" \
-                    "from ./docker-compose_dev.yml..."
-    docker-compose -f docker-compose_dev.yml down >& dc.out >/dev/null
-    cat dc.out                                                              | ./boxes.sh
-    echo "Removing ./FS tree"                                               | ./boxes.sh
+title -d 1 "Destroying pman_dev_stack containerized dev environment on Swarm"
+    echo "This might take a few minutes... please be patient."      | ./boxes.sh ${Yellow}
+    echo "docker stack rm pman_dev_stack"                               | ./boxes.sh ${LightCyan}
+    windowBottom
+    docker stack rm pman_dev_stack >& dc.out >/dev/null
+    echo -en "\033[2A\033[2K"
+    cat dc.out | sed -E 's/(.{80})/\1\n/g'                          | ./boxes.sh ${LightGreen}
+    echo "Removing ./FS tree"                                       | ./boxes.sh
     rm -fr ./FS
-windowBottom
-
-title -d 1 "Stopping swarm cluster..."
-    docker swarm leave --force >dc.out 2>dc.out
-    cat dc.out                                                              | ./boxes.sh
 windowBottom


### PR DESCRIPTION
`pman` service needs to run inside the Swarm, Kubernetes or Openshift cluster. Thus its development environment should reflect that fact. Previously `docker-compose` was being used but it is unable to deploy `pman` inside the local dev swarm cluster.