### PR TITLE
Fix implementation of -S <storeBase> option in shell scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ Dockerfile
 .github
 .git
 LICENSE
+CHRIS_REMOTE_FS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: docker build -t fnndsc/pman .
-      - uses: FNNDSC/cube-integration-action@v4
+      - uses: FNNDSC/cube-integration-action@v5
 
 
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 .vscode/
 
 dc.out
+CHRIS_REMOTE_FS/


### PR DESCRIPTION
The default `STOREBASE` folder is now `./CHRIS_REMOTE_FS`