### PR TITLE
Add label org.chrisproject.role=pman

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           docker build --build-arg ENVIRONMENT=local -t fnndsc/pman:dev .
           ./make.sh -s -U -i
       - name: nosetests
-        run: docker exec $(docker ps -f name=pman_dev_stack_pman.1 -q) nosetests --exe tests
+        run: docker exec $(docker ps -f label=org.chrisproject.role=pman -q | head -n 1) nosetests --exe tests
       - name: teardown
         run: |
           ./unmake.sh

--- a/make.sh
+++ b/make.sh
@@ -219,7 +219,7 @@ title -d 1 "Waiting until pman container is running on $ORCHESTRATOR"
     for i in {1..30}; do
         sleep 5
         if [[ $ORCHESTRATOR == swarm ]]; then
-            pman_dev=$(docker ps -f name=pman_dev_stack_pman.1 -q)
+            pman_dev=$(docker ps -f label=org.chrisproject.role=pman -q | head -n 1)
         elif [[ $ORCHESTRATOR == kubernetes ]]; then
             pman_dev=$(kubectl get pods --selector="app=pman,env=development" --field-selector=status.phase=Running --output=jsonpath='{.items[*].metadata.name}')
         fi

--- a/swarm/docker-compose_dev.yml
+++ b/swarm/docker-compose_dev.yml
@@ -38,3 +38,4 @@ services:
     labels:
       name: "pman"
       role: "pman service"
+      org.chrisproject.role: "pman"

--- a/swarm/prod/docker-compose.yml
+++ b/swarm/prod/docker-compose.yml
@@ -37,6 +37,7 @@ services:
     labels:
       name: "pman"
       role: "pman service"
+      org.chrisproject.role: "pman"
 
 networks:
   remote:


### PR DESCRIPTION
> Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.

https://github.com/opencontainers/image-spec/blob/master/annotations.md#rules

Identifying container ID by a namespaced label is more reliable than guessing what docker swarm automatically names the container.