### PR TITLE
Tail logs

### DIFF
--- a/pman/abstractmgr.py
+++ b/pman/abstractmgr.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, NewType, Optional, TypedDict
+from typing import Generic, TypeVar, NewType, Optional, TypedDict, AnyStr
 from dataclasses import dataclass
 from enum import Enum
 
@@ -99,9 +99,12 @@ class AbstractManager(ABC, Generic[J]):
         ...
 
     @abstractmethod
-    def get_job_logs(self, job: J) -> str:
+    def get_job_logs(self, job: J, tail: int) -> AnyStr:
         """
-        Get the logs string from a previously scheduled job object.
+        Get the logs (combined stdout+stdin) from a previously scheduled job object.
+
+        :param job: the job which to get the logs for
+        :param tail: how many bytes to read from the end of the logs.
         """
         ...
 

--- a/pman/config.py
+++ b/pman/config.py
@@ -20,6 +20,8 @@ class Config:
         env = Env()
         env.read_env()  # also read .env file, if it exists
 
+        self.JOB_LOGS_TAIL = env.int('JOB_LOGS_TAIL', 1000)
+
         self.CONTAINER_ENV = env('CONTAINER_ENV', 'swarm')
         self.STORAGE_TYPE = env('STORAGE_TYPE', 'host')
 

--- a/pman/cromwellmgr.py
+++ b/pman/cromwellmgr.py
@@ -116,7 +116,7 @@ class CromwellManager(AbstractManager[WorkflowId]):
             return job.id
         raise CromwellException(f'No job found for name="{name}"', status_code=404)
 
-    def get_job_logs(self, job: WorkflowId) -> str:
+    def get_job_logs(self, job: WorkflowId, tail: int) -> str:
         # cromwell_tools.utilities.download
         data = self.__client.logs_idc(job)
         return (

--- a/pman/openshiftmgr.py
+++ b/pman/openshiftmgr.py
@@ -241,7 +241,7 @@ class OpenShiftManager(AbstractManager):
         return job
         
                                     
-    def get_job_logs(self,job):
+    def get_job_logs(self, job, tail):
         #return ''
         name = job.metadata.name
         str_logs = ''

--- a/pman/resources.py
+++ b/pman/resources.py
@@ -148,6 +148,7 @@ class JobResource(Resource):
 
         self.container_env = app.config.get('CONTAINER_ENV')
         self.compute_mgr = get_compute_mgr(self.container_env)
+        self.job_logs_tail = app.config.get('JOB_LOGS_TAIL')
 
     def get(self, job_id):
         job_id = job_id.lstrip('/')
@@ -161,7 +162,9 @@ class JobResource(Resource):
         job_info = self.compute_mgr.get_job_info(job)
         logger.info(f'Successful job {job_id} status response from '
                     f'{self.container_env}: {job_info}')
-        job_logs = self.compute_mgr.get_job_logs(job)
+        job_logs = self.compute_mgr.get_job_logs(job, self.job_logs_tail)
+        if isinstance(job_logs, bytes):
+            job_logs = job_logs.decode(encoding='utf-8', errors='replace')
 
         return {
             'jid': job_id,

--- a/pman/resources.py
+++ b/pman/resources.py
@@ -95,7 +95,7 @@ class JobListResource(Resource):
         job_info = compute_mgr.get_job_info(job)
         logger.info(f'Successful job {job_id} schedule response from '
                     f'{self.container_env}: {job_info}')
-        job_logs = compute_mgr.get_job_logs(job)
+        job_logs = ''
 
         return {
             'jid': job_id,

--- a/pman/swarmmgr.py
+++ b/pman/swarmmgr.py
@@ -2,6 +2,7 @@
 Swarm cluster manager module that provides functionality to schedule
 jobs (short-lived services) as well as manage their state in the cluster.
 """
+from typing import AnyStr, Sequence, Iterable
 
 import docker
 from docker.models.services import Service
@@ -52,11 +53,8 @@ class SwarmManager(AbstractManager[Service]):
             raise ManagerException(str(e), status_code=400)
         return job
 
-    def get_job_logs(self, job):
-        """
-        Get the logs from a previously scheduled job object.
-        """
-        return ''.join([l.decode(errors='replace') for l in job.logs(stdout=True, stderr=True)])
+    def get_job_logs(self, job: Service, tail: int) -> AnyStr:
+        return b''.join(job.logs(stdout=True, stderr=True, tail=tail))
 
     def get_job_info(self, job: Service) -> JobInfo:
         """


### PR DESCRIPTION
As mentioned in https://github.com/FNNDSC/pman/issues/197, large job logs cause pman to hang. This is a hotfix for that.

In this change, pman is configurable by an environment variable `JOB_LOGS_TAIL` (default: 1000) which sets the maximum number of lines from the end of the job container's logs that should be read.