### PR TITLE
Delete bad comma

### DIFF
--- a/pman/kubernetesmgr.py
+++ b/pman/kubernetesmgr.py
@@ -140,7 +140,7 @@ class KubernetesManager(AbstractManager[V1Job]):
             env = [k_client.V1EnvVar(name='NVIDIA_VISIBLE_DEVICES', value='all'),
                    k_client.V1EnvVar(name='NVIDIA_DRIVER_CAPABILITIES',
                                      value='compute,utility'),
-                   k_client.V1EnvVar(name='NVIDIA_REQUIRE_CUDA', value='cuda>=9.0')],
+                   k_client.V1EnvVar(name='NVIDIA_REQUIRE_CUDA', value='cuda>=9.0')]
 
         security_context = {
             'allow_privilege_escalation': False,


### PR DESCRIPTION
Fixes a bug: Python interprets `env` as a 1-tuple, which caused to this error when scheduling jobs on Kubernetes where `gpu_limit > 0`:

```
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Job in version \"v1\" cannot be handled as a Job: json: cannot unmarshal array into Go struct field Container.spec.template.spec.containers.env of type v1.EnvVar","reason":"BadRequest","code":400}
```