### PR TITLE
Support Kubernetes single PVC deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ for exactly how it works.
 |----------------------|-------------------------------------------------------|
 | `SECRET_KEY`         | [Flask secret key][flask docs]                        |
 | `CONTAINER_ENV`      | one of: "swarm", "kubernetes", "cromwell"             |
-| `STORAGE_TYPE`       | one of: "host", "nfs"                                 |
+| `STORAGE_TYPE`       | one of: "host", "nfs", "manual"                       |
 | `STOREBASE`          | where job data is stored, [see below](#STOREBASE)     |
 | `NFS_SERVER`         | NFS server address, required when `STORAGE_TYPE=nfs`  |
 | `JOB_LOGS_TAIL`      | (int) maximum size of job logs                        |

--- a/pman/kubernetesmgr.py
+++ b/pman/kubernetesmgr.py
@@ -170,30 +170,26 @@ class KubernetesManager(AbstractManager[V1Job]):
             volume_mounts=[k_client.V1VolumeMount(mount_path='/share',
                                                   name='storebase')]
         )
+
         # configure pod template's spec
-        # storage_type = self.config.get('STORAGE_TYPE')
-        # if storage_type == 'host':
-        #     volume = k_client.V1Volume(
-        #         name='storebase',
-        #         host_path=k_client.V1HostPathVolumeSource(path=mountdir)
-        #     )
-        # # else:
-        # #     volume = k_client.V1Volume(
-        # #         name='storebase',
-        # #         nfs=k_client.V1NFSVolumeSource(server=self.config.get('NFS_SERVER'),
-        # #                                        path=mountdir)
-        # #     )
-        # elif storage_type == 'nfs':
-        #     volume = k_client.V1Volume(
-        #         name='storebase',
-        #         nfs=k_client.V1NFSVolumeSource(server=self.config.get('NFS_SERVER'),
-        #                                         path=mountdir)
-        #     )
-        # else:
-        volume = k_client.V1Volume(
-            name='storebase',
-            persistent_volume_claim=k_client.V1PersistentVolumeClaimVolumeSource(claim_name = 'storebase')
-        )
+        storage_type = self.config.get('STORAGE_TYPE')
+        if storage_type == 'host':
+            volume = k_client.V1Volume(
+                name='storebase',
+                host_path=k_client.V1HostPathVolumeSource(path=mountdir)
+            )
+        elif storage_type == 'nfs':
+            volume = k_client.V1Volume(
+                name='storebase',
+                nfs=k_client.V1NFSVolumeSource(server=self.config.get('NFS_SERVER'),
+                                               path=mountdir)
+            )
+        else:
+            # The claim_name must match the name of a PersistentVolumeClaim in the same namespace which is mounted in pfcon
+            volume = k_client.V1Volume(
+                name='storebase', 
+                persistent_volume_claim=k_client.V1PersistentVolumeClaimVolumeSource(claim_name = 'storebase')
+            )
         template = k_client.V1PodTemplateSpec(
             spec=k_client.V1PodSpec(restart_policy='Never',
                                     containers=[container],

--- a/pman/kubernetesmgr.py
+++ b/pman/kubernetesmgr.py
@@ -256,7 +256,7 @@ class KubernetesManager(AbstractManager[V1Job]):
     @staticmethod
     def __is_container_creating_error(e) -> bool:
         return (
-            isinstnace(e, dict)
+            isinstance(e, dict)
             and 'message' in e
             and 'ContainerCreating' in e['message']
         )

--- a/pman/kubernetesmgr.py
+++ b/pman/kubernetesmgr.py
@@ -171,18 +171,29 @@ class KubernetesManager(AbstractManager[V1Job]):
                                                   name='storebase')]
         )
         # configure pod template's spec
-        storage_type = self.config.get('STORAGE_TYPE')
-        if storage_type == 'host':
-            volume = k_client.V1Volume(
-                name='storebase',
-                host_path=k_client.V1HostPathVolumeSource(path=mountdir)
-            )
-        else:
-            volume = k_client.V1Volume(
-                name='storebase',
-                nfs=k_client.V1NFSVolumeSource(server=self.config.get('NFS_SERVER'),
-                                               path=mountdir)
-            )
+        # storage_type = self.config.get('STORAGE_TYPE')
+        # if storage_type == 'host':
+        #     volume = k_client.V1Volume(
+        #         name='storebase',
+        #         host_path=k_client.V1HostPathVolumeSource(path=mountdir)
+        #     )
+        # # else:
+        # #     volume = k_client.V1Volume(
+        # #         name='storebase',
+        # #         nfs=k_client.V1NFSVolumeSource(server=self.config.get('NFS_SERVER'),
+        # #                                        path=mountdir)
+        # #     )
+        # elif storage_type == 'nfs':
+        #     volume = k_client.V1Volume(
+        #         name='storebase',
+        #         nfs=k_client.V1NFSVolumeSource(server=self.config.get('NFS_SERVER'),
+        #                                         path=mountdir)
+        #     )
+        # else:
+        volume = k_client.V1Volume(
+            name='storebase',
+            persistent_volume_claim=k_client.V1PersistentVolumeClaimVolumeSource(claim_name = 'storebase')
+        )
         template = k_client.V1PodTemplateSpec(
             spec=k_client.V1PodSpec(restart_policy='Never',
                                     containers=[container],

--- a/pman/resources.py
+++ b/pman/resources.py
@@ -52,11 +52,6 @@ class JobListResource(Resource):
 
     def __init__(self):
         super(JobListResource, self).__init__()
-
-        # mounting points for the input and outputdir in the app's container!
-        self.str_app_container_inputdir = '/share/incoming'
-        self.str_app_container_outputdir = '/share/outgoing'
-
         self.container_env = app.config.get('CONTAINER_ENV')
 
     def get(self):
@@ -76,7 +71,7 @@ class JobListResource(Resource):
 
         job_id = args.jid.lstrip('/')
 
-        cmd = self.build_app_cmd(args.args, args.args_path_flags, args.entrypoint, args.type)
+        cmd = self.build_app_cmd(args.args, args.args_path_flags, args.entrypoint, args.type, job_id)
 
         resources_dict = {'number_of_workers': args.number_of_workers,
                           'cpu_limit': args.cpu_limit,
@@ -120,12 +115,15 @@ class JobListResource(Resource):
             args: List[str],
             args_path_flags: Collection[str],
             entrypoint: List[str],
-            plugin_type: Literal['ds', 'fs', 'ts']
+            plugin_type: Literal['ds', 'fs', 'ts'],
+            job_id: str
     ) -> List[str]:
-        cmd = entrypoint + localize_path_args(args, args_path_flags, self.str_app_container_inputdir)
+        input_dir = f'/share/key-{job_id}/incoming'
+        output_dir = f'/share/key-{job_id}/outgoing'
+        cmd = entrypoint + localize_path_args(args, args_path_flags, input_dir)
         if plugin_type == 'ds':
-            cmd.append(self.str_app_container_inputdir)
-        cmd.append(self.str_app_container_outputdir)
+            cmd.append(input_dir)
+        cmd.append(output_dir)
         return cmd
 
 

--- a/pman/resources.py
+++ b/pman/resources.py
@@ -80,10 +80,11 @@ class JobListResource(Resource):
                           }
         share_dir = None
         storage_type = app.config.get('STORAGE_TYPE')
-        if storage_type in ('host', 'nfs'):
-            storebase = app.config.get('STOREBASE')
-            share_dir = os.path.join(storebase, 'key-' + job_id)
-
+        # if storage_type in ('host', 'nfs'):
+        #     storebase = app.config.get('STOREBASE')
+        #     share_dir = os.path.join(storebase, 'key-' + job_id)
+        storebase = app.config.get('STOREBASE')
+        share_dir = os.path.join(storebase, 'key-' + job_id)
         logger.info(f'Scheduling job {job_id} on the {self.container_env} cluster')
 
         compute_mgr = get_compute_mgr(self.container_env)


### PR DESCRIPTION
Adding in changes to kubernetesmgr and resources so that pman works on OpenShift with a named PVC. 'STORAGE_TYPE' environment variable needs to be something other than 'host' or 'nfs', and 'CONTAINER_ENV' needs to be set as 'kubernetes'