### PR TITLE
Docker and podman

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,5 @@ venv/
 
 docker-test-entrypoint.sh
 docker-compose.yml
-
+test_swarm.sh
+test_docker.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install
         run: |
           pip install -r requirements/local.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,19 @@ on:
 
 
 jobs:
-  test-pman:
+  test-docker:
+    name: tests (docker, podman)
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        engine:
+          - docker
+          - podman
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./test_docker.sh '${{ matrix.engine }}'
+
+  test-swarm:
     name: tests (swarm)
     runs-on: ubuntu-22.04
     steps:
@@ -31,7 +43,7 @@ jobs:
       - uses: FNNDSC/cube-integration-action@v6
 
   build:
-    needs: [test-pman, test-cube]
+    needs: [test-docker, test-swarm, test-cube]
     if: github.event_name == 'push' || github.event_name == 'release'
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ on:
 
 
 jobs:
+  test-python:
+    name: unit tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+      - name: Install
+        run: |
+          pip install -r requirements/local.txt
+          pip install -e .
+      - name: Pytest
+        run: pytest --color=yes
+
   test-docker:
     name: tests (docker, podman)
     runs-on: ubuntu-22.04
@@ -43,7 +58,7 @@ jobs:
       - uses: FNNDSC/cube-integration-action@v6
 
   build:
-    needs: [test-docker, test-swarm, test-cube]
+    needs: [test-python, test-docker, test-swarm, test-cube]
     if: github.event_name == 'push' || github.event_name == 'release'
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,14 @@ jobs:
           - podman
     steps:
       - uses: actions/checkout@v3
-      - run: ./test_docker.sh '${{ matrix.engine }}'
+      - name: Test
+        run: |
+          # podman is not configured to allow the Github Actions user to set CPU limits, so we need to ignore them.
+          # https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+          if [ '${{ matrix.engine }}' = 'podman' ]; then
+            export IGNORE_LIMITS=yes
+          fi
+          ./test_docker.sh '${{ matrix.engine }}'
 
   test-swarm:
     name: tests (swarm)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,13 @@ for single-machine use cases.
 
 **`CONTAINER_ENV=docker` is compatible with Podman.**
 
-Podman version 4 or above is required.
+Podman version 3 or 4 are known to work.
+
+#### Rootless Podman
+
+Configure the user to be able to set resource limits.
+
+https://github.com/containers/podman/blob/main/troubleshooting.md#symptom-23
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ for single-machine use cases.
 
 **`CONTAINER_ENV=docker` is compatible with Podman.**
 
+Podman version 4 or above is required.
+
 ### Environment Variables
 
 | Environment Variable | Description                                                             |

--- a/README.md
+++ b/README.md
@@ -116,17 +116,19 @@ https://github.com/containers/podman/blob/main/troubleshooting.md#symptom-23
 
 ### Environment Variables
 
-| Environment Variable | Description                                                             |
-|----------------------|-------------------------------------------------------------------------|
-| `SECRET_KEY`         | [Flask secret key][flask docs]                                          |
-| `CONTAINER_ENV`      | one of: "swarm", "kubernetes", "cromwell", "docker"                     |
-| `STORAGE_TYPE`       | one of: "host", "nfs", "docker_local_volume"                            |
-| `STOREBASE`          | where job data is stored, [see below](#STOREBASE)                       |
-| `VOLUME_NAME`        | name of local volume, valid when `STORAGE_TYPE=docker_local_volume`     |
-| `PFCON_SELECTOR`     | label on the pfcon container (default: `org.chrisproject.role=pfcon`)   |
-| `NFS_SERVER`         | NFS server address, required when `STORAGE_TYPE=nfs`                    |
-| `JOB_LOGS_TAIL`      | (int) maximum size of job logs                                          |
-| `REMOVE_JOBS`        | If set to "no" then pman will not delete jobs (debug)                   |
+| Environment Variable | Description                                                            |
+|----------------------|------------------------------------------------------------------------|
+| `SECRET_KEY`         | [Flask secret key][flask docs]                                         |
+| `CONTAINER_ENV`      | one of: "swarm", "kubernetes", "cromwell", "docker"                    |
+| `STORAGE_TYPE`       | one of: "host", "nfs", "docker_local_volume"                           |
+| `STOREBASE`          | where job data is stored, [see below](#STOREBASE)                      |
+| `VOLUME_NAME`        | name of local volume, valid when `STORAGE_TYPE=docker_local_volume`    |
+| `PFCON_SELECTOR`     | label on the pfcon container (default: `org.chrisproject.role=pfcon`)  |
+| `NFS_SERVER`         | NFS server address, required when `STORAGE_TYPE=nfs`                   |
+| `JOB_LABELS`         | CSV list of key=value pairs, labels to apply to container jobs         |
+| `JOB_LOGS_TAIL`      | (int) maximum size of job logs                                         |
+| `IGNORE_LIMITS`      | If set to "yes" then do not set resource limits on container jobs      |
+| `REMOVE_JOBS`        | If set to "no" then pman will not delete jobs (debug)                  |
 
 [flask docs]: https://flask.palletsprojects.com/en/2.1.x/config/#SECRET_KEY
 
@@ -171,6 +173,12 @@ Applicable when `CONTAINER_ENV=cromwell`
 | `TIMELIMIT_MINUTES`  | SLURM job time limit                                 |
 
 For how it works, see https://github.com/FNNDSC/pman/wiki/Cromwell
+
+## Missing Features
+
+- `IGNORE_LIMITS=yes` only works with `CONTAINER_ENV=docker` (or podman).
+- `JOB_LABELS=...` only works with `CONTAINER_ENV=docker` (or podman).
+- `CONTAINER_ENV=cromwell` does not forward environment variables.
 
 ## TODO
 

--- a/docker-test-entrypoint.sh
+++ b/docker-test-entrypoint.sh
@@ -19,7 +19,7 @@ print(storebase)
 export STOREBASE="$(python -c "$py")"
 >&2 echo "Detected host path of STOREBASE=$STOREBASE"
 
-export APPLICATION_MODE=development CONTAINER_ENV=swarm PYTHONDONTWRITEBYTECODE=1
+export STORAGE_TYPE=host APPLICATION_MODE=development CONTAINER_ENV=swarm PYTHONDONTWRITEBYTECODE=1
 
 if [ "$#" -eq 0 ]; then
   set -x

--- a/pman/_helpers.py
+++ b/pman/_helpers.py
@@ -1,0 +1,43 @@
+from typing import Optional
+import docker
+from docker import DockerClient
+
+PFCON_STOREBASE_DESTINATION = '/var/local/storeBase'
+"""
+Path inside pfcon container where the storebase volume is mounted.
+"""
+
+def get_storebase_from_docker(pfcon_selector: Optional[str], volume_id: Optional[str]) -> str:
+    """
+    Use docker (or Podman) to automatically identify a local volume to use as store base.
+
+    The volume name can be given by name. Alternatively, it can be found by trying to detect
+    the volume name automatically from pfcon.
+    """
+    d = docker.from_env()
+
+    if volume_id is not None:
+        return get_local_volume_by_id(d, volume_id)
+
+    return get_volume_from_pfcon(d, pfcon_selector)
+
+
+def get_local_volume_by_id(d: DockerClient, volume_id: str) -> str:
+    a = d.volumes.get(volume_id).attrs
+    if a['Driver'] != 'local':
+        raise ValueError(f'Volume "{a["Name"]}" uses unsupported driver: {a["Driver"]}')
+    return a['Mountpoint']
+
+
+def get_volume_from_pfcon(d: DockerClient, pfcon_selector: str) -> str:
+    containers = d.containers.list(filters={'label': pfcon_selector})
+    if not containers:
+        raise ValueError(f'No container found with label {pfcon_selector}')
+
+    container = containers[0]
+    mounts = container.attrs['Mounts']
+    mountpoints = (v['Source'] for v in mounts if v['Destination'] == PFCON_STOREBASE_DESTINATION)
+    mountpoint = next(mountpoints, None)
+    if mountpoint is None:
+        raise ValueError(f'Container {container.id} does not have a mount to {PFCON_STOREBASE_DESTINATION}')
+    return mountpoint

--- a/pman/abstractmgr.py
+++ b/pman/abstractmgr.py
@@ -85,7 +85,9 @@ class AbstractManager(ABC, Generic[J]):
 
     @abstractmethod
     def schedule_job(self, image: Image, command: List[str], name: JobName,
-                     resources_dict: Resources, env: List[str], mountdir: Optional[str] = None) -> J:
+                     resources_dict: Resources, env: List[str],
+                     uid: Optional[int], gid: Optional[int],
+                     mountdir: Optional[str] = None) -> J:
         """
         Schedule a new job and return the job object.
         """

--- a/pman/config.py
+++ b/pman/config.py
@@ -26,6 +26,9 @@ class Config:
         self.JOB_LOGS_TAIL = env.int('JOB_LOGS_TAIL', 1000)
         self.JOB_LABELS = env.dict('JOB_LABELS', {})
         self.IGNORE_LIMITS = env.bool('IGNORE_LIMITS', False)
+        self.ENABLE_RANDOM_USER = env.bool('ENABLE_RANDOM_USER', False)
+        self.ENABLE_HOME_WORKAROUND = env.bool('ENABLE_HOME_WORKAROUND', False)
+
         self.CONTAINER_ENV = env('CONTAINER_ENV', 'docker')
         if self.CONTAINER_ENV == 'podman':  # podman is just an alias for docker
             self.CONTAINER_ENV = 'docker'

--- a/pman/config.py
+++ b/pman/config.py
@@ -144,12 +144,6 @@ class ProdConfig(Config):
                     'class': 'logging.StreamHandler',
                     'formatter': 'simple',
                 },
-                'file': {
-                    'level': 'DEBUG',
-                    'class': 'logging.FileHandler',
-                    'filename': '/tmp/debug.log',
-                    'formatter': 'simple'
-                }
             },
             'loggers': {
                 '': {  # root logger
@@ -158,7 +152,7 @@ class ProdConfig(Config):
                 },
                 'pman': {  # pman package logger
                     'level': 'INFO',
-                    'handlers': ['file'],
+                    'handlers': ['console_simple'],
                     'propagate': False
                 },
             }

--- a/pman/config.py
+++ b/pman/config.py
@@ -26,6 +26,9 @@ class Config:
         self.JOB_LOGS_TAIL = env.int('JOB_LOGS_TAIL', 1000)
 
         self.CONTAINER_ENV = env('CONTAINER_ENV', 'docker')
+        if self.CONTAINER_ENV == 'podman':  # podman is just an alias for docker
+            self.CONTAINER_ENV = 'docker'
+
         default_storage_type = 'docker_local_volume' if self.CONTAINER_ENV == 'docker' else None
         self.STORAGE_TYPE = env('STORAGE_TYPE', default_storage_type)
 

--- a/pman/config.py
+++ b/pman/config.py
@@ -26,7 +26,7 @@ class Config:
         self.JOB_LOGS_TAIL = env.int('JOB_LOGS_TAIL', 1000)
         self.JOB_LABELS = env.dict('JOB_LABELS', {})
         self.IGNORE_LIMITS = env.bool('IGNORE_LIMITS', False)
-        self.ENABLE_RANDOM_USER = env.bool('ENABLE_RANDOM_USER', False)
+        self.CONTAINER_USER = env.bool('CONTAINER_USER', False)
         self.ENABLE_HOME_WORKAROUND = env.bool('ENABLE_HOME_WORKAROUND', False)
 
         self.CONTAINER_ENV = env('CONTAINER_ENV', 'docker')
@@ -61,8 +61,6 @@ class Config:
 
         if self.CONTAINER_ENV == 'kubernetes':
             self.JOB_NAMESPACE = env('JOB_NAMESPACE', 'default')
-            self.SECURITYCONTEXT_RUN_AS_USER = env.int('SECURITYCONTEXT_RUN_AS_USER', None)
-            self.SECURITYCONTEXT_RUN_AS_GROUP = env.int('SECURITYCONTEXT_RUN_AS_GROUP', None)
 
         if self.CONTAINER_ENV == 'cromwell':
             self.CROMWELL_URL = env('CROMWELL_URL')

--- a/pman/config.py
+++ b/pman/config.py
@@ -24,7 +24,8 @@ class Config:
         env.read_env()  # also read .env file, if it exists
 
         self.JOB_LOGS_TAIL = env.int('JOB_LOGS_TAIL', 1000)
-
+        self.JOB_LABELS = env.dict('JOB_LABELS', {})
+        self.IGNORE_LIMITS = env.bool('IGNORE_LIMITS', False)
         self.CONTAINER_ENV = env('CONTAINER_ENV', 'docker')
         if self.CONTAINER_ENV == 'podman':  # podman is just an alias for docker
             self.CONTAINER_ENV = 'docker'
@@ -32,7 +33,7 @@ class Config:
         default_storage_type = 'docker_local_volume' if self.CONTAINER_ENV == 'docker' else None
         self.STORAGE_TYPE = env('STORAGE_TYPE', default_storage_type)
 
-        self.REMOVE_JOBS = env('REMOVE_JOBS', 'yes').lower() != 'no'
+        self.REMOVE_JOBS = env.bool('REMOVE_JOBS', True)
 
         if self.STORAGE_TYPE == 'host' or self.STORAGE_TYPE == 'nfs':
             self.STOREBASE = env('STOREBASE')

--- a/pman/container_user.py
+++ b/pman/container_user.py
@@ -1,0 +1,61 @@
+import random
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ContainerUser:
+    """
+    Helper for parsing the UID/GID from the ``CONTAINER_USER`` environment variable
+    configuration of *pman*.
+    """
+    uid: None | int | tuple[int, int]
+    """Given UID or UID range"""
+    gid: None | int | tuple[int, int]
+    """Given GID or GID range"""
+
+    @classmethod
+    def parse(cls, config_value: Optional[str]) -> 'ContainerUser':
+        """Constructor"""
+        s = cls._split(config_value)
+        uid, gid = map(cls._parse_range, s)
+        return cls(uid, gid)
+
+    def get_uid(self) -> Optional[int]:
+        """
+        Get UID. If UID was given as a range, return a random number in that range.
+        """
+        return self.__get_value(self.uid)
+
+    def get_gid(self) -> Optional[int]:
+        """
+        Get GID. If GID was given as a range, return a random number in that range.
+        """
+        return self.__get_value(self.gid)
+
+    @staticmethod
+    def __get_value(s: None | int | tuple[int, int]) -> int:
+        if s is None or isinstance(s, int):
+            return s
+        lo, hi = s
+        return random.randint(lo, hi)
+
+    @staticmethod
+    def _split(config_value: Optional[str]) -> tuple[str, str]:
+        if not config_value:
+            config_value = ':'
+        split = config_value.split(':')
+        if len(split) != 2:
+            raise ValueError(f'CONTAINER_USER="{config_value}" does not match format UID:GID')
+        left, right = split
+        return left, right
+
+    @staticmethod
+    def _parse_range(value: str) -> None | int | tuple[int, int]:
+        if not value:
+            return None
+        try:
+            lo, hi = map(int, value.split('-'))
+            return lo, hi
+        except ValueError:
+            return int(value)

--- a/pman/cromwellmgr.py
+++ b/pman/cromwellmgr.py
@@ -61,7 +61,10 @@ class CromwellManager(AbstractManager[WorkflowId]):
         self.__client = CromwellClient(auth)
 
     def schedule_job(self, image: Image, command: List[str], name: JobName,
-                     resources_dict: Resources, mountdir: Optional[str] = None) -> WorkflowId:
+                     resources_dict: Resources,
+                     env: List[str], uid: Optional[int], gid: Optional[int],
+                     mountdir: Optional[str] = None) -> WorkflowId:
+        # TODO env, uid, gid is ignored
         wdl = SlurmJob(image, command, mountdir, resources_dict, self.__timelimit).to_wdl()
         res = self.__submit(wdl, name)
         # Submission does not appear in Cromwell immediately, but pman wants to

--- a/pman/dockermgr.py
+++ b/pman/dockermgr.py
@@ -1,10 +1,93 @@
-"""
-Interface between pman and docker engine API.
+import shlex
+from collections import defaultdict
+from typing import List, Optional, AnyStr
+
+from docker import DockerClient
+from docker.models.containers import Container
+
+from pman.abstractmgr import AbstractManager, Image, JobName, Resources, JobInfo, TimeStamp, ManagerException, JobStatus
+import docker
 
 
-"""
-from pman.abstractmgr import AbstractManager
+class DockerManager(AbstractManager[Container]):
+    """
+    Interface between pman and Docker Engine or Podman API.
+    """
+    def __init__(self, config_dict=None, docker_client: DockerClient = None):
+        super().__init__(config_dict)
+        if docker_client is not None:
+            self.__docker = docker_client
+        else:
+            self.__docker = docker.from_env()
+
+    def schedule_job(self, image: Image, command: List[str], name: JobName, resources_dict: Resources, env: List[str],
+                     mountdir: Optional[str] = None) -> Container:
+        if resources_dict['number_of_workers'] != 1:
+            raise ManagerException(
+                'Compute environment only supports number_of_workers=1, '
+                'got number_of_workers=' + str(resources_dict['number_of_workers']),
+                status_code=400
+            )
+        if resources_dict['gpu_limit'] != 0:
+            raise ManagerException('Compute environment does not support GPUs yet.')
+
+        kwargs = {}
+        if mountdir is not None:
+            kwargs['volumes'] = {mountdir: {'bind': '/share', 'mode': 'rw'}}
+
+        return self.__docker.containers.run(
+            image=image,
+            command=command,
+            name=name,
+            nano_cpus=int(resources_dict['cpu_limit'] * 1e6),
+            mem_reservation=(resources_dict['memory_limit'] * 1024 * 1024),
+            environment=env,
+            restart_policy = {'Name': 'no', 'MaximumRetryCount': 0},
+            detach=True,
+            **kwargs
+        )
+
+    def get_job(self, name: JobName) -> Container:
+        try:
+            return self.__docker.containers.get(name)
+        except docker.errors.NotFound as e:
+            raise ManagerException(str(e), status_code=404)
+
+    def get_job_logs(self, job: Container, tail: int) -> AnyStr:
+        return job.logs(stdout=True, stderr=True, tail=tail)
+
+    def get_job_info(self, job: Container) -> JobInfo:
+        return JobInfo(
+            name=JobName(job.name),
+            image=Image(job.attrs['Config']['Image']),
+            cmd=shlex.join(job.attrs['Config']['Cmd']),
+            timestamp=_get_timestamp_from(job),
+            message=job.attrs['State']['Status'],
+            status=_get_status_from(job)
+        )
+
+    def remove_job(self, job: Container):
+        job.remove(force=True)
 
 
-class SwarmManager(AbstractManager[Unknown]):
-    ...
+def _get_timestamp_from(c: Container) -> TimeStamp:
+    state = c.attrs['State']
+    if state['FinishedAt'] != '0001-01-01T00:00:00Z':
+        return state['FinishedAt']
+    return state['StartedAt']
+
+
+def _get_status_from(c: Container) -> JobStatus:
+    # see https://docs.docker.com/engine/api/v1.42/#tag/Container/operation/ContainerInspect
+    state = c.attrs['State']
+    if state['Running'] or state['Paused']:
+        return JobStatus.started
+    if state['Status'] == 'created':
+        return JobStatus.notstarted
+    if state['OOMKilled'] or state['Dead']:
+        return JobStatus.finishedWithError
+    if state['Status'] == 'exited':
+        if state['ExitCode'] == 0:
+            return JobStatus.finishedSuccessfully
+        return JobStatus.finishedWithError
+    return JobStatus.undefined

--- a/pman/dockermgr.py
+++ b/pman/dockermgr.py
@@ -1,0 +1,10 @@
+"""
+Interface between pman and docker engine API.
+
+
+"""
+from pman.abstractmgr import AbstractManager
+
+
+class SwarmManager(AbstractManager[Unknown]):
+    ...

--- a/pman/dockermgr.py
+++ b/pman/dockermgr.py
@@ -1,5 +1,4 @@
 import shlex
-from collections import defaultdict
 from typing import List, Optional, AnyStr
 
 from docker import DockerClient

--- a/pman/resources.py
+++ b/pman/resources.py
@@ -77,6 +77,9 @@ class JobListResource(Resource):
             if len(s.split('=', 1)) != 2:
                 abort(400, message='"env" must be a list of "key=value" strings')
 
+        if app.config.get('ENABLE_HOME_WORKAROUND'):
+            args.env.append('HOME=/tmp')
+
         job_id = args.jid.lstrip('/')
 
         cmd = self.build_app_cmd(args.args, args.args_path_flags, args.entrypoint, args.type)

--- a/pman/resources.py
+++ b/pman/resources.py
@@ -7,6 +7,7 @@ from flask import current_app as app
 from flask_restful import reqparse, abort, Resource
 
 from .abstractmgr import ManagerException
+from .container_user import ContainerUser
 from .dockermgr import DockerManager
 from .openshiftmgr import OpenShiftManager
 from .kubernetesmgr import KubernetesManager
@@ -62,6 +63,8 @@ class JobListResource(Resource):
 
         self.container_env = app.config.get('CONTAINER_ENV')
 
+        self.user = ContainerUser.parse(app.config.get('CONTAINER_USER'))
+
     def get(self):
         return {
             'server_version': app.config.get('SERVER_VERSION')
@@ -103,7 +106,7 @@ class JobListResource(Resource):
         compute_mgr = get_compute_mgr(self.container_env)
         try:
             job = compute_mgr.schedule_job(args.image, cmd, job_id, resources_dict,
-                                           args.env, share_dir)
+                                           args.env, self.user.get_uid(), self.user.get_gid(), share_dir)
         except ManagerException as e:
             logger.error(f'Error from {self.container_env} while scheduling job '
                          f'{job_id}, detail: {str(e)}')

--- a/pman/swarmmgr.py
+++ b/pman/swarmmgr.py
@@ -19,7 +19,7 @@ class SwarmManager(AbstractManager[Service]):
         else:
             self.docker_client = docker.from_env(environment=self.config)
 
-    def schedule_job(self, image, command, name, resources_dict, env, mountdir=None) -> \
+    def schedule_job(self, image, command, name, resources_dict, env, uid, gid, mountdir=None) -> \
             Service:
         """
         Schedule a new job and return the job (swarm service) object.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Flask==1.1.4
 Flask-RESTful==0.3.9
-docker==4.4.4
+docker==6.0.1
 openshift==0.12.0
 kubernetes==12.0.1
 python-keystoneclient==4.2.0

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -67,7 +67,7 @@ podman run --rm \
 
 # pman identifies the aforementioned volume by inspecting
 # its peer pfcon, so run a mock pfcon container
-mock_pfcon=$(podman run --rm -d -v "$volume:/var/local/storeBase" -l org.chrisproject.role=pfcon alpine sleep 60)
+mock_pfcon=$(podman run -d -v "$volume:/var/local/storeBase" -l org.chrisproject.role=pfcon alpine sleep 60)
 
 # run pman in the background
 
@@ -75,7 +75,7 @@ mock_pfcon=$(podman run --rm -d -v "$volume:/var/local/storeBase" -l org.chrispr
 # see .github/workflows/ci.yml
 
 pman=$(
-  podman run --rm -d --userns host -p 5010:5010 \
+  podman run -d --userns host -p 5010:5010 \
     -e IGNORE_LIMITS \
     -v $socket:/var/run/docker.sock:rw \
     -e SECRET_KEY=secret -e CONTAINER_ENV=$CONTAINER_RUNTIME \
@@ -167,5 +167,6 @@ EOF
 # clean up
 set -ex
 podman kill $pman $mock_pfcon
+podman rm $pman $mock_pfcon
 podman volume rm $volume
 # podman rmi $pman_image  # optional

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -1,0 +1,163 @@
+#!/bin/bash -e
+# Test pman in isolation with docker OR podman
+#
+# Notes:
+# - state is dirty if tests fail
+# - suggested that you run this script with no existing containers nor volumes
+
+set -o pipefail
+
+HERE=$(dirname "$(readlink -f "$0")")
+
+CONTAINER_RUNTIME=$1
+
+if [ -z "$CONTAINER_RUNTIME" ]; then
+  echo "usage: $0 [docker|podman]"
+  exit 1
+fi
+
+CR_EXEC=$(which $CONTAINER_RUNTIME)
+
+# shadows the name "podman" so that it calls the specified runtime
+# which might be docker OR podman
+function podman () {
+  $CR_EXEC "$@"
+}
+
+# find out where the podman/docker socket is
+if [ -n "$DOCKER_HOST" ]; then
+  socket="$DOCKER_HOST"
+else
+  if [[ "$CR_EXEC" = *podman* ]]; then
+    if [ "$(podman info --format '{{ .Host.RemoteSocket.Exists }}')" != 'true' ]; then
+      echo "error: podman socket must be active."
+      echo "try running:"
+      echo
+      echo "    systemctl --user start podman.service"
+      echo
+      exit 1
+    fi
+    socket="$(podman info --format '{{ .Host.RemoteSocket.Path }}')"
+  elif [[ "$CR_EXEC" = *docker* ]]; then
+    socket=/var/run/docker.sock
+  fi
+fi
+
+set -ex
+
+# pull example ChRIS plugin
+SIMPLEDSAPP=docker.io/fnndsc/pl-simpledsapp:2.1.0
+podman pull $SIMPLEDSAPP
+
+# build
+pman_image="localhost/fnndsc/pman:${0##*/}"
+podman build -t $pman_image .
+
+# "storebase" directory where "pfcon" writes data
+volume=$(podman volume create --driver local)
+storeBase=$(podman volume inspect --format '{{ .Mountpoint }}' $volume)
+
+# simulate action of pfcon receiving data
+jid="pmantest-$RANDOM"
+
+podman run --rm \
+  -v "$HERE:/here:ro" -w /here \
+  -v "$volume:/var/local/storeBase:rw"  \
+  alpine sh -c "mkdir -vp /var/local/storeBase/key-$jid/incoming /var/local/storeBase/key-$jid/outgoing && cp -v README.md LICENSE /var/local/storeBase/key-$jid/incoming"
+
+# pman identifies the aforementioned volume by inspecting
+# its peer pfcon, so run a mock pfcon container
+mock_pfcon=$(podman run --rm -d -v "$volume:/var/local/storeBase" -l org.chrisproject.role=pfcon alpine sleep 60)
+
+# run pman in the background
+pman=$(
+  podman run --rm -d --userns host -p 5010:5010 \
+    -v $socket:/var/run/docker.sock:rw \
+    -e SECRET_KEY=secret -e CONTAINER_ENV=$CONTAINER_RUNTIME \
+    $pman_image
+)
+
+# wait for pman to be up
+set +e
+elapsed=0
+until [ "$(curl -w '%{http_code}' -o /dev/null -s --head http://localhost:5010/api/v1/)" = "200" ]; do
+  sleep 1
+  if [  "$((elapsed++))" -gt "5" ]; then
+    echo "error: timed out waiting for pman"
+    exit 1
+  fi
+done
+
+# submit job to pman
+set -e
+body="$(cat << EOF
+{
+  "jid": "$jid",
+  "args": [
+    "--saveinputmeta", "--saveoutputmeta",
+    "--prefix", "hello_test_"
+  ],
+  "auid": "cube-test",
+  "number_of_workers": "1",
+  "cpu_limit": "1000",
+  "memory_limit": "200",
+  "gpu_limit": "0",
+  "image": "$SIMPLEDSAPP",
+  "entrypoint": ["simpledsapp"],
+  "type": "ds"
+}
+EOF
+)"
+
+curl -H 'Accept: application/json' -H 'Content-Type: application/json' \
+  --data "$body" http://localhost:5010/api/v1/
+
+
+# assert pman created container, and that STOREBASE was mounted
+podman container inspect --format '{{ range .Mounts }}{{ .Source }}{{end}}' $jid \
+  | grep -Fqm 1 "$storeBase/key-$jid"
+
+# wait for simpledsapp to finish
+rc=$(podman wait $jid)
+if [ "$rc" != "0" ]; then
+  echo "failed assertion: $jid exited with code $rc"
+  exit $rc
+fi
+
+# assert simpledsapp worked
+podman run --rm -v "$storeBase/key-$jid:/share:ro" alpine diff -rq \
+  "/share/incoming/README.md" \
+  "/share/outgoing/hello_test_README.md"
+
+# assert pman reports simpledsapp finishedSuccessfully
+status="$(curl -H 'Accept: application/json' http://localhost:5010/api/v1/$jid/ | jq -r '.status')"
+
+if [ "$status" != "finishedSuccessfully" ]; then
+  echo "failed assertion: pman reports $jid has status \"$status\""
+  exit 1
+fi
+
+# delete job
+set +e
+curl -qX DELETE http://localhost:5010/api/v1/$jid/
+set +o pipefail
+podman container inspect $jid 2>&1 | grep -Fqm 1 "no such container" \
+  || (echo "assertion failed: container $jid not deleted"; exit 1)
+
+set +x
+
+cat << EOF
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!                            !!
+!!        TESTS PASSED        !!
+!!                            !!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+EOF
+
+# clean up
+set -ex
+podman kill $pman $mock_pfcon
+podman volume rm $volume
+# podman rmi $pman_image  # optional

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -110,8 +110,9 @@ EOF
 )"
 
 curl -H 'Accept: application/json' -H 'Content-Type: application/json' \
-  --data "$body" http://localhost:5010/api/v1/
+  --data "$body" -q http://localhost:5010/api/v1/
 
+podman logs $pman  # debug output
 
 # assert pman created container, and that STOREBASE was mounted
 podman container inspect --format '{{ range .Mounts }}{{ .Source }}{{end}}' $jid \
@@ -123,6 +124,8 @@ if [ "$rc" != "0" ]; then
   echo "failed assertion: $jid exited with code $rc"
   exit $rc
 fi
+
+podman logs $jid  # debug output
 
 # assert simpledsapp worked
 podman run --rm -v "$storeBase/key-$jid:/share:ro" alpine diff -rq \

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -70,8 +70,13 @@ podman run --rm \
 mock_pfcon=$(podman run --rm -d -v "$volume:/var/local/storeBase" -l org.chrisproject.role=pfcon alpine sleep 60)
 
 # run pman in the background
+
+# IGNORE_LIMITS is forwarded to the container as a workaround for a Github Actions bug,
+# see .github/workflows/ci.yml
+
 pman=$(
   podman run --rm -d --userns host -p 5010:5010 \
+    -e IGNORE_LIMITS \
     -v $socket:/var/run/docker.sock:rw \
     -e SECRET_KEY=secret -e CONTAINER_ENV=$CONTAINER_RUNTIME \
     $pman_image

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -115,7 +115,7 @@ EOF
 )"
 
 curl -H 'Accept: application/json' -H 'Content-Type: application/json' \
-  --data "$body" -q http://localhost:5010/api/v1/
+  --data "$body" -s http://localhost:5010/api/v1/
 
 podman logs $pman  # debug output
 
@@ -138,7 +138,7 @@ podman run --rm -v "$storeBase/key-$jid:/share:ro" alpine diff -rq \
   "/share/outgoing/hello_test_README.md"
 
 # assert pman reports simpledsapp finishedSuccessfully
-status="$(curl -H 'Accept: application/json' http://localhost:5010/api/v1/$jid/ | jq -r '.status')"
+status="$(curl -sH 'Accept: application/json' http://localhost:5010/api/v1/$jid/ | jq -r '.status')"
 
 if [ "$status" != "finishedSuccessfully" ]; then
   echo "failed assertion: pman reports $jid has status \"$status\""
@@ -147,7 +147,7 @@ fi
 
 # delete job
 set +e
-curl -qX DELETE http://localhost:5010/api/v1/$jid/
+curl -sX DELETE http://localhost:5010/api/v1/$jid/
 set +o pipefail
 podman container inspect $jid 2>&1 | grep -Fqm 1 "no such container" \
   || (echo "assertion failed: container $jid not deleted"; exit 1)

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -145,6 +145,10 @@ if [ "$status" != "finishedSuccessfully" ]; then
   exit 1
 fi
 
+## pause for manual inspection
+#echo "press any key to continue..."
+#read -n 1 _whatever
+
 # delete job
 set +e
 curl -sX DELETE http://localhost:5010/api/v1/$jid/
@@ -165,7 +169,8 @@ cat << EOF
 EOF
 
 # clean up
-set -ex
+set +e
+set -x
 podman kill $pman $mock_pfcon
 podman rm $pman $mock_pfcon
 podman volume rm $volume

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,6 @@ def docker_client() -> DockerClient:
 @pytest.fixture(scope='session')
 def podman_client() -> DockerClient:
     sock = f'unix:///run/user/{os.getuid()}/podman/podman.sock'
-    if os.path.exists(sock):
+    if not os.path.exists(sock):
         raise pytest.skip(f'{sock} not found')
     return docker.DockerClient(base_url=sock)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import os.path
+
+import pytest
+import docker
+from docker import DockerClient
+
+
+@pytest.fixture(scope='session')
+def docker_client() -> DockerClient:
+    return docker.from_env()
+
+
+@pytest.fixture(scope='session')
+def podman_client() -> DockerClient:
+    sock = f'unix:///run/user/{os.getuid()}/podman/podman.sock'
+    if os.path.exists(sock):
+        raise pytest.skip(f'{sock} not found')
+    return docker.DockerClient(base_url=sock)

--- a/tests/cromwell/test_cromwellmgr.py
+++ b/tests/cromwell/test_cromwellmgr.py
@@ -50,6 +50,7 @@ class CromwellTestCase(unittest.TestCase):
             Image('fnndsc/pl-simpledsapp'), 'simpledsapp /in /out',
             JobName('example-jid-4567'),
             self.example_resources,
+            [], None, None,
             '/storeBase/whatever'
         )
 
@@ -84,6 +85,7 @@ class CromwellTestCase(unittest.TestCase):
             self.manager.schedule_job(
                 Image('fnndsc/pl-simpledsapp'), 'simpledsapp /in /out',
                 JobName('example-jid-4567'), self.example_resources,
+                [], None, None,
                 '/storeBase/whatever'
             )
 

--- a/tests/test_container_user.py
+++ b/tests/test_container_user.py
@@ -1,0 +1,45 @@
+import pytest
+import random
+
+from pman.container_user import ContainerUser
+
+
+@pytest.mark.parametrize(
+    'value, expected',
+    [
+        (None, ContainerUser(uid=None, gid=None)),
+        ('', ContainerUser(uid=None, gid=None)),
+        (':', ContainerUser(uid=None, gid=None)),
+        ('1000:', ContainerUser(uid=1000, gid=None)),
+        ('1000-1234:', ContainerUser(uid=(1000, 1234), gid=None)),
+        ('1000-1234:5678', ContainerUser(uid=(1000, 1234), gid=5678)),
+        ('1000-1234:5678-12345', ContainerUser(uid=(1000, 1234), gid=(5678,12345))),
+    ]
+)
+def test_parse_container_user(value: str, expected: ContainerUser):
+    assert ContainerUser.parse(value) == expected
+
+
+def test_get_uid_gid():
+    user = ContainerUser(uid=12345, gid=6789)
+    assert user.get_uid() == 12345
+    assert user.get_gid() == 6789
+
+
+def test_random_get_uid(example_ranged_user):
+    state = random.getstate()
+    next_random = random.randint(example_ranged_user.uid[0], example_ranged_user.uid[1])
+    random.setstate(state)
+    assert example_ranged_user.get_uid() == next_random
+
+
+def test_random_get_gid(example_ranged_user):
+    state = random.getstate()
+    next_random = random.randint(example_ranged_user.gid[0], example_ranged_user.gid[1])
+    random.setstate(state)
+    assert example_ranged_user.get_gid() == next_random
+
+
+@pytest.fixture
+def example_ranged_user() -> ContainerUser:
+    return ContainerUser(uid=(1000, 9000000), gid=(1000, 9000000))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,56 @@
+import pytest
+from docker import DockerClient
+from docker.models.volumes import Volume
+import pman._helpers as helpers
+
+from contextlib import contextmanager
+
+
+def test_podman_storebase_volume_name(podman_client):
+    storebase_volume_name_helper(podman_client)
+
+
+def test_docker_storebase_volume_name(docker_client):
+    storebase_volume_name_helper(docker_client)
+
+
+def test_podman_storebase_from_pfcon(podman_client):
+    storebase_from_pfcon_helper(podman_client)
+
+
+def test_docker_storebase_from_pfcon(docker_client):
+    storebase_from_pfcon_helper(docker_client)
+
+
+def storebase_from_pfcon_helper(d: DockerClient):
+    with create_volume(d) as v:
+        _pfcon = d.containers.run(
+            image='alpine',
+            command=['sleep', '100'],
+            detach=True,
+            volumes={v.name: {'bind': helpers.PFCON_STOREBASE_DESTINATION}},
+            labels={'org.chrisproject.role': 'dummy-pfcon'}
+        )
+
+        actual = helpers.get_volume_from_pfcon(d, 'org.chrisproject.role=dummy-pfcon')
+        expected = v.attrs['Mountpoint']
+    assert actual == expected
+
+
+def storebase_volume_name_helper(d: DockerClient):
+    with create_volume(d) as v:
+        actual = helpers.get_local_volume_by_id(d, v.name)
+        expected = v.attrs['Mountpoint']
+    assert actual == expected
+
+
+@contextmanager
+def create_volume(d: DockerClient) -> Volume:
+    v = d.volumes.create()
+    try:
+        yield v
+    finally:
+        for c in d.containers.list(filters={'volume': v.name}):
+            c.kill()
+            c.remove(force=True)
+        v.remove(force=True)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,11 +1,11 @@
 
 import logging
+import unittest
 from pathlib import Path
 import shutil
 import os
 import time
 from unittest import TestCase
-from unittest import mock, skip
 
 from flask import url_for
 
@@ -30,6 +30,8 @@ class ResourceTests(TestCase):
         logging.disable(logging.NOTSET)
 
 
+@unittest.skipIf('STOREBASE' not in os.environ,
+                 'Cannot start pman without STOREBASE')
 class TestJobListResource(ResourceTests):
     """
     Test the JobListResource resource.


### PR DESCRIPTION
- Added `dockermgr.py` which uses Docker Engine (or Podman) API (without swarm mode)
- Added a feature where `STOREBASE` can be detected from a local volume automatically
- `CONTAINER_ENV=docker STORAGE_TYPE=docker_local_volume` are the new defaults (instead of `CONTAINER_ENV=swarm STORAGE_TYPE=host`)
  - new defaults enable (near) zero-config deployment (still need to provide `SECRET_KEY`)
- Added setting `CONTAINER_USER`, which replaces `SECURITYCONTEXT_RUNAS_USER` and `SECURITYCONTEXT_RUNAS_GROUP` (backwards incompatible)
- Added setting `ENABLE_HOME_WORKAROUND` for working around bugs where `CONTAINER_USER` is underprivileged 

See the changes to README.md for thoughts on deployment

